### PR TITLE
Fixes #54

### DIFF
--- a/eclide/ChildAttributeFrame.cpp
+++ b/eclide/ChildAttributeFrame.cpp
@@ -158,6 +158,12 @@ public:
 		return blankString.c_str();
 	}
 
+	const TCHAR * GetTabTip(std::_tstring & tabTip)
+	{
+		tabTip = GetPath();
+		return tabTip.c_str();
+	}
+
 	BEGIN_MSG_MAP(thisClass)
 		MSG_WM_CREATE(OnCreate)
 		MSG_WM_SIZE(OnSize)

--- a/eclide/ChildBuilderFrame.cpp
+++ b/eclide/ChildBuilderFrame.cpp
@@ -383,6 +383,16 @@ public:
 		return m_dlgview.GetPath();
 	}
 
+	const TCHAR * GetTabTip(std::_tstring & tabTip)
+	{
+		if (CComPtr<IAttribute> attr = m_dlgview.GetAttribute())
+		{
+			tabTip = std::_tstring(_T("[")) + attr->GetQualifiedLabel() + _T("] ");
+		}
+		tabTip += GetPath();
+		return tabTip.c_str();
+	}
+
 	//  IResultSlot override  ---
 	bool WorkunitUpdated(Dali::IWorkunit * workunit, bool bFirst)
 	{
@@ -754,6 +764,7 @@ void CBuilderFrame::UIUpdateTitle()
 
 bool CBuilderFrame::UIUpdateMenuItems(CCmdUI * cui)
 {
+	GetIMainFrame()->DisableAllMenuItems();
 	IResultViewer *pResult = ActiveResultsWindow();
 	if (pResult)
 	{
@@ -789,6 +800,8 @@ bool CBuilderFrame::UIUpdateMenuItems(CCmdUI * cui)
 			if (m_dlgview.m_archiveButton.IsWindowEnabled())
 				m_dlgview.m_archiveButton.EnableWindow(false);
 		}
+
+		UPDATEUI(cui, ID_ECL_SYNCTOC, m_dlgview.GetAttribute() != NULL);
 	}
 	return false;
 }

--- a/eclide/ChildGraphFrame.cpp
+++ b/eclide/ChildGraphFrame.cpp
@@ -108,9 +108,16 @@ public:
 			return true;
 		return false;
 	}
+
 	const TCHAR * GetPath()
 	{
 		return m_path.c_str();
+	}
+
+	const TCHAR * GetTabTip(std::_tstring & tabTip)
+	{
+		tabTip = GetPath();
+		return tabTip.c_str();
 	}
 
 	//  File Access  ---

--- a/eclide/EclDlgBuilder.cpp
+++ b/eclide/EclDlgBuilder.cpp
@@ -119,6 +119,7 @@ bool CBuilderDlg::DoFileSave(const CString & sPathName)
 	}
 
 	// Save file name for later
+	m_attribute = NULL;				//Attribute detaches on SaveAs (as user could be saving anywhere)
 	SetNamePath(newPath);	
 	m_view.SetSavePoint();
 

--- a/eclide/WtlMDIChildFrame.h
+++ b/eclide/WtlMDIChildFrame.h
@@ -224,8 +224,10 @@ afx_msg LRESULT CWtlMDIChildFrame<ViewT>::OnGetTooltip(WPARAM wParam, LPARAM lPa
 {
 
 	std::_tstring * tooltip = (std::_tstring *)wParam;
-	if (tooltip)
-		*tooltip = m_view->GetPath();
+	if (tooltip) 
+	{
+		m_view->GetTabTip(*tooltip);
+	}
 	return 0;
 }
 

--- a/eclide/mainfrm.cpp
+++ b/eclide/mainfrm.cpp
@@ -1914,17 +1914,24 @@ LRESULT CMainFrame::OnGetTabToolTip(WPARAM /*wp*/, LPARAM lp)
 
 	if (pInfo)
 	{
-		ASSERT_VALID (pInfo->m_pTabWnd);
-		if (!pInfo->m_pTabWnd->IsMDITab ())
-		{
+		ASSERT_VALID(pInfo->m_pTabWnd);
+		if (!pInfo->m_pTabWnd->IsMDITab())
 			return 0;
-		}
-		std::_tstring tooltip;
-		HWND hWnd = GetActive();
+
+		HWND hWnd = NULL;
+		CWnd * wnd = pInfo->m_pTabWnd->GetTabWnd(pInfo->m_nTabIndex);
+		if (wnd)
+			hWnd = wnd->GetSafeHwnd();
+		if (hWnd == NULL || !::IsWindow(hWnd))
+			hWnd = GetActive();
+
 		if (::IsWindow(hWnd))
+		{
+			std::_tstring tooltip;
 			::SendMessage(hWnd, CWM_GETTOOLTIPTEXT, (WPARAM)&tooltip, NULL);
-		if (!tooltip.empty())
-			pInfo->m_strText = tooltip.c_str();
+			if (!tooltip.empty())
+				pInfo->m_strText = tooltip.c_str();
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
MDI Tab Tooltip always showed active tab text.
MDI Tab Tooltip now indicates path + ATTRIBUTE LABEL (if known)

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
