### PR TITLE
Modules/Folders containing "." causes crash.

### DIFF
--- a/comms/DiskRepository.cpp
+++ b/comms/DiskRepository.cpp
@@ -141,6 +141,7 @@ protected:
 	fs::wpath m_amtRoot;
 	StringCMonitorFolderMap m_paths;
 	PathVector m_pathOrder;
+	mutable clib::recursive_mutex m_mutex;
 
 public:
 	IMPLEMENT_CUNKNOWN;
@@ -178,7 +179,7 @@ public:
 		if (fs::exists(path) && fs::is_directory(path))
 		{
 			std::_tstring leaf = path.leaf();
-			if (!algo::starts_with(leaf, _T(".")))
+			if (!algo::contains(leaf, _T(".")))
 			{  
 				std::_tstring label = module;
 				if (!label.empty())
@@ -200,6 +201,7 @@ public:
 
 	virtual unsigned GetAllModules(IModuleVector & _modules, IModuleHierarchy & _moduleHierarchy, bool GetChecksum = false, bool noRefresh = true, bool noBroadcast = false) const
 	{
+		clib::recursive_mutex::scoped_lock proc(m_mutex);
 		IModuleVector modules;
 		IModuleHierarchy moduleHierarchy;
 		for(PathVector::const_iterator itr = m_pathOrder.begin(); itr != m_pathOrder.end(); ++itr)
@@ -474,7 +476,7 @@ public:
 
 	bool GetRepositoryPath(std::_tstring & module, fs::wpath & path) const
 	{
-		if (!m_amtRoot.empty() && !algo::istarts_with(module, m_amtRoot.leaf()))
+		if (!m_amtRoot.empty() && !algo::istarts_with(module, (m_amtRoot.leaf() + _T("."))))
 			module = m_amtRoot.leaf() + _T(".") + module;
 
 		CModuleHelper modHelper(module);


### PR DESCRIPTION
Stops crash on folder containing "." but does this by ignoring them.  More thought will be needed on how (if we can) fix this issue.

Partial Fix for Issue #62

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
