### PR TITLE
Attribute can be opened in builder window and submitted.

### DIFF
--- a/eclide/ChildBuilderFrame.cpp
+++ b/eclide/ChildBuilderFrame.cpp
@@ -157,6 +157,11 @@ public:
 			activeWnd.SetFocus();
 	}
 
+	void SetAttribute(IAttribute *attribute)
+	{
+		m_dlgview.SetAttribute(attribute);
+	}
+
 	void SetEcl(const CString & ecl, bool resetSavePoint)
 	{
 		m_dlgview.SetSource(ecl, resetSavePoint, true);
@@ -374,7 +379,14 @@ public:
 		m_results.insert(m_results.begin(), result);
 		result->Create(m_tabbedChildWindow);
 		m_tabbedChildWindow.AddTab(result->GetHwnd(), _T("Submitted"), 0, 1);
-		result->ExecEcl(m_dlgview.GetCluster(), m_dlgview.GetQueue(), action, ecl, isDrilldown ? _T("") : m_dlgview.GetPath(), when.c_str(), label, m_dlgview.GetResultLimit(), m_dlgview.GetDebug(), m_dlgview.IsArchive(), m_dlgview.GetMaxRuntime(), isDebug);
+		std::_tstring debugStr = m_dlgview.GetDebug();
+		if (CComPtr<IAttribute> attr = m_dlgview.GetAttribute())
+		{
+			if (!debugStr.empty())
+				debugStr += _T("\n");
+			debugStr += std::_tstring(_T("eclcc-main=")) + attr->GetQualifiedLabel(true);
+		}
+		result->ExecEcl(m_dlgview.GetCluster(), m_dlgview.GetQueue(), action, ecl, isDrilldown ? _T("") : m_dlgview.GetPath(), when.c_str(), label, m_dlgview.GetResultLimit(), debugStr.c_str(), m_dlgview.IsArchive(), m_dlgview.GetMaxRuntime(), isDebug);
 		GetIConfig(QUERYBUILDER_CFG)->Set(GLOBAL_QUEUE, m_dlgview.GetQueue());
 		GetIConfig(QUERYBUILDER_CFG)->Set(GLOBAL_CLUSTER, m_dlgview.GetCluster());
 		PostStatus(_T(""));
@@ -1082,6 +1094,7 @@ HWND OpenBuilderMDI(CMainFrame* pFrame, IAttribute *src, IWorkspaceItem * worksp
 	{
 		pChild = new CChildBuilderFrm(workspaceItem);
 		CreateNewChild(pFrame, pChild, IDR_BUILDERWINDOW, _T("builder.ecl"));
+		pChild->m_view->SetAttribute(src);
 		pChild->m_view->SetEcl(src->GetText(), true);
 	}
 	return ((CMDIChildWnd *)pChild)->GetSafeHwnd();

--- a/eclide/EclDlgBuilder.cpp
+++ b/eclide/EclDlgBuilder.cpp
@@ -120,26 +120,30 @@ bool CBuilderDlg::DoFileSave(const CString & sPathName)
 	}
 
 	// Save file name for later
-	m_attribute = NULL;				//Attribute detaches on SaveAs (as user could be saving anywhere)
-	SetNamePath(newPath);	
+	if (SetNamePath(newPath))
+		m_attribute = NULL;				//Attribute detaches on SaveAs (as user could be saving anywhere).
+
 	m_view.SetSavePoint();
 
 	return TRUE;
 }
 
-void CBuilderDlg::SetNamePath(const CString & sPathName)
+bool CBuilderDlg::SetNamePath(const CString & sPathName)
 {	
-	CString pathName = sPathName;
-	TCHAR szTitle [_MAX_FNAME], szExt[_MAX_FNAME];
-	_tsplitpath(pathName.GetBuffer(_MAX_PATH), NULL, NULL, szTitle, szExt);
-	pathName.ReleaseBuffer();
-	lstrcat(szTitle, szExt);			
+	if (!boost::filesystem::equivalent(static_cast<const TCHAR *>(m_path), static_cast<const TCHAR *>(sPathName)))
+	{
+		CString pathName = sPathName;
+		TCHAR szTitle [_MAX_FNAME], szExt[_MAX_FNAME];
+		_tsplitpath(pathName.GetBuffer(_MAX_PATH), NULL, NULL, szTitle, szExt);
+		pathName.ReleaseBuffer();
+		lstrcat(szTitle, szExt);			
 
-	m_path = sPathName;
-	if (szTitle) 
-		m_name = szTitle;
-	
-	//ATLASSERT(!"TODO:  UIUpdateTitle()");
+		m_path = sPathName;
+		if (szTitle) 
+			m_name = szTitle;
+		return true;
+	}
+	return false;
 }
 
 const TCHAR * CBuilderDlg::GetPath() const

--- a/eclide/EclDlgBuilder.h
+++ b/eclide/EclDlgBuilder.h
@@ -72,7 +72,7 @@ public:
 	bool DoFileOpen(const CString & sPathName);
 	bool DoFileSave(const CString & sPathName);
 	bool DoFileSaveAs();
-	void SetNamePath(const CString & sPathName);
+	bool SetNamePath(const CString & sPathName);
 	const TCHAR * GetPath() const;
 
 	void SetQueueCluster(const CString & queue, const CString & cluster);


### PR DESCRIPTION
Would previously fail if it was from a remote repository + the attribute was nested within modules.

Will still fail in legacy environment.

Fixes #47

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
