### PR TITLE
Add Copy button to about screen.

### DIFF
--- a/comms/SMC.cpp
+++ b/comms/SMC.cpp
@@ -40,7 +40,7 @@ public:
 
 	CSMC(const CString & url, const CString & label) : m_label(label), m_url(url)
 	{
-		m_unknown = CreateVersion(_T("http://www.seisint.com/"), _T("build_0_0"));
+		m_unknown = CreateVersion(_T("http://www.seisint.com/"), DEFAULT_VERSION);
 	}
 
 	~CSMC()
@@ -219,7 +219,7 @@ public:
 
 	CSMC(const CString & url, const CString & label) : m_label(label), m_url(url)
 	{
-		m_unknown = CreateVersion(_T("http://www.seisint.com/"), _T("build_0_0"));
+		m_unknown = CreateVersion(_T("http://www.seisint.com/"), DEFAULT_VERSION);
 	}
 
 	~CSMC()

--- a/comms/SMCVersion.cpp
+++ b/comms/SMCVersion.cpp
@@ -82,7 +82,7 @@ public:
 		else
 			m_CommsVer = parsedVersion.majorVersion * 100 + parsedVersion.minorVersion;
 
-		if (m_strversion.empty())
+		if (m_strversion.empty() && !boost::algorithm::equals(static_cast<const TCHAR *>(version), DEFAULT_VERSION))
 			m_strversion = version;
 	}
 

--- a/comms/SMCVersion.h
+++ b/comms/SMCVersion.h
@@ -5,6 +5,7 @@
 
 namespace SMC
 {
+const TCHAR * const DEFAULT_VERSION = _T("build_0_0");
 __interface IVersion : public IUnknown
 {
 	float Get();

--- a/en_us/en_us.rc
+++ b/en_us/en_us.rc
@@ -28,8 +28,8 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 6, 0, 4, 4
- PRODUCTVERSION 6, 0, 4, 4
+ FILEVERSION 6,0,4,4
+ PRODUCTVERSION 6,0,4,4
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -46,12 +46,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "TODO: <Company name>"
             VALUE "FileDescription", "TODO: <File description>"
-            VALUE "FileVersion", "6, 0, 4, 4\0"
+            VALUE "FileVersion", "6, 0, 4, 4"
             VALUE "InternalName", "en_us.dll"
             VALUE "LegalCopyright", "TODO: (c) <Company name>.  All rights reserved."
             VALUE "OriginalFilename", "en_us.dll"
             VALUE "ProductName", "TODO: <Product name>"
-            VALUE "ProductVersion", "6, 0, 4, 4\0"
+            VALUE "ProductVersion", "6, 0, 4, 4"
         END
     END
     BLOCK "VarFileInfo"
@@ -495,6 +495,7 @@ BEGIN
     LTEXT           "---------",IDC_STATIC_BEVEL,5,92,285,8
     LTEXT           "Warning: ",IDC_STATIC_WARNING,10,100,220,40
     DEFPUSHBUTTON   "OK",IDOK,235,100,50,14
+    PUSHBUTTON      "&Copy",ID_EDIT_COPY,236,76,50,14
 END
 
 IDD_LOGIN DIALOGEX 0, 0, 210, 97
@@ -2679,8 +2680,4 @@ LANGUAGE 9, 1
 
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
-
-
-
-
 

--- a/wlib/AboutDlg.cpp
+++ b/wlib/AboutDlg.cpp
@@ -15,10 +15,13 @@ class CAboutDlg : public CDialogImpl<CAboutDlg>,
 	public CWinDataExchange<CAboutDlg>
 {
 protected:
-	CString m_warning;
 	CBevelLine m_ctlBevel;
 	std::_tstring m_title;
+	std::_tstring m_version;
+	std::_tstring m_server;
+	std::_tstring m_compiler;
 	CString m_product;
+	CString m_warning;
 	CIcon m_icon;
 
 public:
@@ -35,6 +38,7 @@ public:
 
 	BEGIN_MSG_MAP(CAboutDlg)
 		MESSAGE_HANDLER(WM_INITDIALOG, OnInitDialog)
+		COMMAND_ID_HANDLER(ID_EDIT_COPY, OnCopy)
 		COMMAND_ID_HANDLER(IDOK, OnCloseCmd)
 		COMMAND_ID_HANDLER(IDCANCEL, OnCloseCmd)
 	END_MSG_MAP()
@@ -57,27 +61,34 @@ public:
 
 		CenterWindow(GetParent());
 
-		std::_tstring version = _T("Version:\t\t");
-		GetAboutVersion(version);
-		SetDlgItemText(IDC_STATIC_VERSION, version.c_str());
+		m_version = _T("Version:\t\t");
+		GetAboutVersion(m_version);
+		SetDlgItemText(IDC_STATIC_VERSION, m_version.c_str());
 
 		CComPtr<SMC::ISMC> smc = SMC::AttachSMC(GetIConfig(QUERYBUILDER_CFG)->Get(GLOBAL_SERVER_SMC), _T("SMC"));
 
-		std::_tstring server = _T("Server:\t\t");
+		m_server = _T("Server:\t\t");
 		CComPtr<SMC::IVersion> serverVersion = smc->GetBuild();
-		server += serverVersion->GetString();
-		SetDlgItemText(IDC_STATIC_SERVER, server.c_str());
+		m_server += serverVersion->GetString();
+		SetDlgItemText(IDC_STATIC_SERVER, m_server.c_str());
 
-		std::_tstring compiler = _T("Compiler:\t");
+		m_compiler = _T("Compiler:\t");
 		if (CComPtr<IEclCC> eclcc = CreateIEclCC())
-			compiler += eclcc->GetVersion();
+			m_compiler += eclcc->GetVersion();
 		else
-			compiler += _T("Unknown");
-		SetDlgItemText(IDC_STATIC_COMPILER, compiler.c_str());
+			m_compiler += _T("Unknown");
+		SetDlgItemText(IDC_STATIC_COMPILER, m_compiler.c_str());
 
 		CenterWindow(GetParent());
 		return TRUE;
 	}
+
+	LRESULT OnCopy(WORD /*wNotifyCode*/, WORD wID, HWND /*hWndCtl*/, BOOL& /*bHandled*/)
+	{
+		SetClipboard((boost::_tformat(_T("%1%\r\n%2%\r\n%3%\r\n")) % m_version % m_server % m_compiler).str());
+		return 0;
+	}
+
 	LRESULT OnCloseCmd(WORD /*wNotifyCode*/, WORD wID, HWND /*hWndCtl*/, BOOL& /*bHandled*/)
 	{
 		EndDialog(wID);


### PR DESCRIPTION
(Ctrl+C works on all dialogs anyway, but this is specific to version information).

Don't display build_0_0 which is the internal "no version" build number).

Fixes #75

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
