### PR TITLE
BUG:17 SALT Support for local repositories.

### DIFF
--- a/amt/RepositoryCompareView.cpp
+++ b/amt/RepositoryCompareView.cpp
@@ -606,7 +606,7 @@ bool CRepositoryCompareView::DoMigration()
 						m_migrator->AddToRep(*i);
 				}
 				for (IAttributeHistoryVector::const_iterator i = attrs.begin(); i != attrs.end(); ++i)
-					m_migrator->AddToRep(*i, _T(""), sandbox);
+					m_migrator->AddToRep(NULL, *i, _T(""), sandbox);
 				m_migrator->Start();
 				m_sel.Clear();
 			}

--- a/comms/AttributeImpl.h
+++ b/comms/AttributeImpl.h
@@ -82,7 +82,7 @@ public:
 			errorFile.HandsOff();
 			
 			std::_tstring cmd = (boost::_tformat(_T("cmd /c %1% %2% %3% %4% %5% %6% %7%")) % 
-				batchFile.c_str() % PREPROCESS_LABEL[action] % GetModuleQualifiedLabel() % GetLabel() % 
+				batchFile.c_str() % PREPROCESS_LABEL[action] % GetModuleQualifiedLabel(true) % GetLabel() % 
 				inputFile.TempFileName() % outputFile.TempFileName() % errorFile.TempFileName()).str();
 
 			//_DBGLOG(m_url, LEVEL_INFO, cmd.c_str());

--- a/comms/DiskAttribute.cpp
+++ b/comms/DiskAttribute.cpp
@@ -222,7 +222,8 @@ public:
 			m_checksum = m_checksumLocal;
 
 			proc.unlock();
-			Refresh(true, NULL, false);
+			if (!noBroadcast)
+				Refresh(true, NULL, false);
 			result = true;
 		}
 		return result;

--- a/comms/DiskModule.cpp
+++ b/comms/DiskModule.cpp
@@ -365,6 +365,16 @@ public:
 		return m_access;
 	}
 
+	IModule * GetRootModule() const
+	{
+		clib::recursive_mutex::scoped_lock proc(m_mutex);
+		const IModule * module = this;
+		while(module->GetParentModule() != NULL) {
+			module = module->GetParentModule();
+		}
+		return const_cast<IModule *>(module);
+	}
+
 	IModule * GetParentModule() const
 	{
 		clib::recursive_mutex::scoped_lock proc(m_mutex);

--- a/comms/Migration.cpp
+++ b/comms/Migration.cpp
@@ -146,7 +146,7 @@ protected:
 		{
 #endif
 			if (module)
-				modAttr.first = module->GetLabel() + std::_tstring(_T(".")) + modAttr.first;
+				modAttr.first = module->GetQualifiedLabel() + std::_tstring(_T(".")) + modAttr.first;
 			self->m_caller->LogMsg((boost::_tformat(_T("%1%.%2%:  Migration Start")) % modAttr.first % modAttr.second).str());
 			IModuleAdapt toMod = GetModule(self->m_targetRep, modAttr.first.c_str());
 			if (!toMod)
@@ -289,9 +289,9 @@ protected:
 #endif
 	}
 
-	static void thread_AddToRep(CComPtr<CMigration> self, IAttributeHistoryAdapt fromAttr, const std::_tstring comment, bool sandbox)
+	static void thread_AddToRep(CComPtr<CMigration> self, IModuleAdapt targetModule, IAttributeHistoryAdapt fromAttr, const std::_tstring comment, bool sandbox)
 	{
-		thread_AddEclToModule(self, NULL, ModAttrPair(fromAttr->GetModuleQualifiedLabel(true), fromAttr->GetLabel()), fromAttr->GetType(), comment, GetText(fromAttr), fromAttr->GetModifiedBy(), fromAttr->GetModifiedDate(), sandbox);
+		thread_AddEclToModule(self, targetModule, ModAttrPair(fromAttr->GetModuleQualifiedLabel(true), fromAttr->GetLabel()), fromAttr->GetType(), comment, GetText(fromAttr), fromAttr->GetModifiedBy(), fromAttr->GetModifiedDate(), sandbox);
 	}
 
 
@@ -316,9 +316,9 @@ public:
 		m_threads.Append(__FUNCTION__, boost::bind(&thread_AddWsToRep, this, fromWorkspace));
 	}
 
-	void AddToRep(IAttributeHistoryAdapt fromAttr, const std::_tstring & comment, bool sandbox)
+	void AddToRep(IModuleAdapt targetModule, IAttributeHistoryAdapt fromAttr, const std::_tstring & comment, bool sandbox)
 	{
-		m_threads.Append(__FUNCTION__, boost::bind(&thread_AddToRep, this, fromAttr, comment, sandbox));
+		m_threads.Append(__FUNCTION__, boost::bind(&thread_AddToRep, this, targetModule, fromAttr, comment, sandbox));
 	}
 
 	void AddEclToRep(const std::_tstring & modLabel, const std::_tstring & attrLabel, IAttributeType * type, const std::_tstring & comment, const std::_tstring & ecl, const std::_tstring & by, bool sandbox)

--- a/comms/Migration.h
+++ b/comms/Migration.h
@@ -16,7 +16,7 @@ __interface IMigrationCallback
 __interface IMigration : public IUnknown
 {
 	void AddToRep(IWorkspaceAdapt fromWorkspace);
-	void AddToRep(IAttributeHistoryAdapt fromAttr, const std::_tstring & comment, bool sandbox);
+	void AddToRep(IModuleAdapt targetModule, IAttributeHistoryAdapt fromAttr, const std::_tstring & comment, bool sandbox);
 	void AddEclToRep(const std::_tstring & modLabel, const std::_tstring & attrLabel, IAttributeType * type, const std::_tstring & comment, const std::_tstring & ecl, const std::_tstring & by, bool sandbox);
 	void AddEclToRep(const std::_tstring & modAttrLabel, IAttributeType * type, const std::_tstring & comment, const std::_tstring & ecl, const std::_tstring & by, bool sandbox);
 	void AddEclToModule(IModuleAdapt module, const std::_tstring & modLabel, const std::_tstring & attrLabel, IAttributeType * type, const std::_tstring & comment, const std::_tstring & ecl, const std::_tstring & by, bool sandbox);

--- a/comms/ModFileAttribute.cpp
+++ b/comms/ModFileAttribute.cpp
@@ -143,7 +143,6 @@ public:
 	const TCHAR *GetModuleQualifiedLabel(bool excludeRoot = false) const
 	{
 		clib::recursive_mutex::scoped_lock proc(m_mutex);
-		ATLASSERT(!excludeRoot);
 		return m_moduleQualifiedLabel;
 	}
 

--- a/comms/ModFileModule.cpp
+++ b/comms/ModFileModule.cpp
@@ -81,6 +81,11 @@ public:
 		return m_access;
 	}
 
+	IModule * GetRootModule() const
+	{
+		return NULL;
+	}
+
 	IModule * GetParentModule() const
 	{
 		clib::recursive_mutex::scoped_lock proc(m_mutex);

--- a/comms/Module.cpp
+++ b/comms/Module.cpp
@@ -86,6 +86,11 @@ public:
 		return m_access;
 	}
 
+	IModule * GetRootModule() const
+	{
+		return NULL;
+	}
+
 	IModule * GetParentModule() const
 	{
 		clib::recursive_mutex::scoped_lock proc(m_mutex);

--- a/comms/Module.h
+++ b/comms/Module.h
@@ -21,6 +21,7 @@ __interface IModule : public clib::ILockableUnknown
 	const TCHAR *GetQualifiedLabel(bool excludeRoot = false) const;
 	const TCHAR *GetPath() const;
 	const SecAccessFlags GetAccess() const;
+	IModule * GetRootModule() const;	//  Will be NULL for non local repositories...
 	IModule * GetParentModule() const;
 	unsigned GetModules(IModuleVector & modules, bool noRefresh=false) const;
 	unsigned GetAttributes(IAttributeVector & attributes, bool noRefresh=false) const;

--- a/eclide/EclDlgAttribute.cpp
+++ b/eclide/EclDlgAttribute.cpp
@@ -59,7 +59,7 @@ bool CAttributeDlg::DoSave(bool attrOnly)
 				m_migrator = CreateIMigration(::AttachRepository());
 			m_migrator->Stop();
 			for(IAttributeVector::const_iterator itr = attrs.begin(); itr != attrs.end(); ++itr)
-				m_migrator->AddToRep(itr->get()->GetAsHistory(), (boost::_tformat(_T("Preprocessed (%1%) from %2%.")) % PREPROCESS_LABEL[PREPROCESS_SAVE] % m_attribute->GetQualifiedLabel()).str().c_str(), true);
+				m_migrator->AddToRep(m_attribute->GetModule()->GetRootModule(), itr->get()->GetAsHistory(), (boost::_tformat(_T("Preprocessed (%1%) from %2%.")) % PREPROCESS_LABEL[PREPROCESS_SAVE] % m_attribute->GetQualifiedLabel()).str().c_str(), true);
 			m_migrator->Start();
 			m_migrator->Join();
 			SendMessage(CWM_SUBMITDONE, Dali::WUActionCheck, (LPARAM)&errors);

--- a/eclide/EclDlgBuilder.cpp
+++ b/eclide/EclDlgBuilder.cpp
@@ -69,8 +69,9 @@ bool CBuilderDlg::DoSave(bool attrOnly)
 			if (!m_migrator)
 				m_migrator = CreateIMigration(::AttachRepository());
 			m_migrator->Stop();
+
 			for(IAttributeVector::const_iterator itr = attrs.begin(); itr != attrs.end(); ++itr)
-				m_migrator->AddToRep(itr->get()->GetAsHistory(), (boost::_tformat(_T("Preprocessed (%1%) from %2%.")) % PREPROCESS_LABEL[PREPROCESS_SAVE] % m_attribute->GetQualifiedLabel()).str().c_str(), true);
+				m_migrator->AddToRep(m_attribute->GetModule()->GetRootModule(), itr->get()->GetAsHistory(), (boost::_tformat(_T("Preprocessed (%1%) from %2%.")) % PREPROCESS_LABEL[PREPROCESS_SAVE] % m_attribute->GetQualifiedLabel()).str().c_str(), true);
 			m_migrator->Start();
 			m_migrator->Join();
 			SendMessage(CWM_SUBMITDONE, Dali::WUActionCheck, (LPARAM)&errors);


### PR DESCRIPTION
Enable SALT integration for local repository configurations.

When saving a ".salt" file it is assumed the generated files belong in
the same local repository as the ".salt" file.  This removes the need
to specify a target repository (which is still needed when importing a
.mod file).

Fixes #17
