### PR TITLE
Remove BugTrap Screenshot

### DIFF
--- a/amt/AMT.cpp
+++ b/amt/AMT.cpp
@@ -52,7 +52,7 @@ BOOL CAMTApp::InitInstance()
 	// Setup exception handler
 	BT_SetAppName(_T("Attribute Migration Tool"));
 	BT_SetSupportEMail(_T("gsmith@seisint.com"));
-	BT_SetFlags(BTF_DETAILEDMODE | BTF_EDITMAIL | BTF_ATTACHREPORT| BTF_SCREENCAPTURE);
+	BT_SetFlags(BTF_DETAILEDMODE | BTF_EDITMAIL | BTF_ATTACHREPORT);
     BT_SetSupportURL(_T("http://hpccsystems.com/support"));
 
 

--- a/eclide/QueryBuilder.cpp
+++ b/eclide/QueryBuilder.cpp
@@ -63,7 +63,7 @@ BOOL CQueryBuilderApp::InitInstance()
 	// Setup exception handler
 	BT_SetAppName(_T("ECL IDE"));
 	BT_SetSupportEMail(_T("support_eclide@hpccsystems.com"));
-	BT_SetFlags(BTF_DETAILEDMODE | BTF_EDITMAIL | BTF_ATTACHREPORT| BTF_SCREENCAPTURE);
+	BT_SetFlags(BTF_DETAILEDMODE | BTF_EDITMAIL | BTF_ATTACHREPORT);
     BT_SetSupportURL(_T("http://hpccsystems.com/support"));
 
 	// = BugTrapServer ===========================================


### PR DESCRIPTION
Removed the automated screenshot feature from generated bugtrap reports.

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
