### PR TITLE
IDE-196 IDE reverts to local repository after viewing preferences window...

### DIFF
--- a/eclide/mainfrm.cpp
+++ b/eclide/mainfrm.cpp
@@ -2117,7 +2117,7 @@ void CMainFrame::DoLogout()
 	m_wndRibbonBar.SendMessage(WM_IDLEUPDATECMDUI, true);
 }
 
-void CMainFrame::DoLogin(bool SkipLoginWindow)
+void CMainFrame::DoLogin(bool SkipLoginWindow, const CString & previousPassword)
 {
 	if (!SkipLoginWindow)
 	{
@@ -2137,6 +2137,10 @@ void CMainFrame::DoLogin(bool SkipLoginWindow)
 		MessageBox(_T("Only one instance of ECL IDE is permitted with the same \"Configuration\" and \"Login ID\"."), CString(MAKEINTRESOURCE(IDR_MAINFRAME)), MB_OK | MB_ICONEXCLAMATION);
 		DoLogin();
 		return;
+	}
+	if (SkipLoginWindow)
+	{
+		GetIConfig(QUERYBUILDER_CFG)->Set(GLOBAL_PASSWORD, previousPassword);
 	}
 	if (CComPtr<IEclCC> eclcc = CreateIEclCC())
 	{
@@ -3340,6 +3344,8 @@ bool CMainFrame::ShowConfigPreference(IConfig *config)
 
 void CMainFrame::OnFilePreferences()
 {
+	CString previousPassword = GetIConfig(QUERYBUILDER_CFG)->Get(GLOBAL_PASSWORD);
+
 	DoLogout();
 
 	if (::ShowPreferencesDlg(GetIConfig(QUERYBUILDER_CFG), true))
@@ -3348,7 +3354,7 @@ void CMainFrame::OnFilePreferences()
 		::SetDefaultConfig(m_iniFile, ::GetIConfig(QUERYBUILDER_CFG)->GetLabel());
 	}
 
-	DoLogin(true);
+	DoLogin(true, previousPassword);
 }
 
 void CMainFrame::OnFileLogin()

--- a/eclide/mainfrm.h
+++ b/eclide/mainfrm.h
@@ -506,7 +506,7 @@ public:
 
 	bool UIUpdateMenuItems();
 	void DoLogout();
-	void DoLogin(bool SkipLoginWindow = false);
+	void DoLogin(bool SkipLoginWindow = false, const CString & previousPassword = _T(""));
 	void RestoreState();
 	void PostSelectRibbon(RIBBON ribbon);
 	void DoPopupFileNew(LPNMTOOLBAR /*lpnmtb*/);


### PR DESCRIPTION
....

If the user opens the preferences window while logged into the IDE, the IDE can lose its password cache while it re-tests to see if the remote repository is valid, which causes it to switch to local repository.

Fixes IDE-196

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
