### PR TITLE
IDE-133 Title bar incorrect after login.

### DIFF
--- a/eclide/mainfrm.cpp
+++ b/eclide/mainfrm.cpp
@@ -2086,6 +2086,7 @@ void CMainFrame::DoLogout()
 	CString title;
 	title.LoadString(IDR_MAINFRAME);
 	SetTitle(title);
+	UpdateFrameTitleForDocument(NULL);
 
 	DoWorkspaceSave();
 	EnumChildWindows(GetSafeHwnd(), ChildEnumProc, CWM_CLOSEALL);
@@ -2167,6 +2168,7 @@ void CMainFrame::DoLogin(bool SkipLoginWindow, const CString & previousPassword)
 	environment += _T(" - ");
 	environment += title;
 	SetTitle(environment.c_str());
+	UpdateFrameTitleForDocument(NULL);
 
 	std::_tstring version;
 	GetAboutVersion(version);


### PR DESCRIPTION
The title bar would not be refreshed with the new configuration name until
after a document was opened.

Fixes IDE-133

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
