### PR TITLE
IDE-202 GraphControl (64 bit) digital signature drops the last .1001

### DIFF
--- a/setup/doPreBuildSetup.bat
+++ b/setup/doPreBuildSetup.bat
@@ -15,4 +15,4 @@ set STAGE_DIR=%ROOT_DIR%\stage
 %strSignCode% sign /f "%SETUP_DIR%\hpcc_code_signing.pfx" /p %pw% /t %strTimeStampUrl% "%STAGE_DIR%\PF\HPCC\ECL IDE\*.exe" 
 %strSignCode% sign /f "%SETUP_DIR%\hpcc_code_signing.pfx" /p %pw% /t %strTimeStampUrl% "%STAGE_DIR%\PF\HPCC\ECL IDE\*.dll" 
 %strSignCode% sign /f "%SETUP_DIR%\hpcc_code_signing.pfx" /p %pw% /t %strTimeStampUrl% "%STAGE_DIR%\PF\HPCC\Graph Control\*.dll" 
-%strSignCode% sign /f "%SETUP_DIR%\hpcc_code_signing.pfx" /p %pw% /t %strTimeStampUrl% "%STAGE_DIR%\PF\HPCC\Graph Control x64\*.dll" 
+REM %strSignCode% sign /f "%SETUP_DIR%\hpcc_code_signing.pfx" /p %pw% /t %strTimeStampUrl% "%STAGE_DIR%\PF\HPCC\Graph Control x64\*.dll" 


### PR DESCRIPTION
It appears that digitally signing the 64bit DLL truncates the version resource.
In this case it removes the last .1001 and ends up with .0.

Fixes IDE-202

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
