### PR TITLE
IDE-225 Salt auto import hangs.

### DIFF
--- a/eclide/EclDlgAttribute.cpp
+++ b/eclide/EclDlgAttribute.cpp
@@ -53,6 +53,7 @@ bool CAttributeDlg::DoSave(bool attrOnly)
 		IAttributeVector attrs;
 		Dali::CEclExceptionVector errors;
 		m_attribute->PreProcess(PREPROCESS_SAVE, NULL, attrs, errors);
+		SendMessage(CWM_SUBMITDONE, Dali::WUActionCheck, (LPARAM)&errors);
 		if (attrs.size())
 		{
 			if (!m_migrator)
@@ -61,16 +62,22 @@ bool CAttributeDlg::DoSave(bool attrOnly)
 			for(IAttributeVector::const_iterator itr = attrs.begin(); itr != attrs.end(); ++itr)
 				m_migrator->AddToRep(m_attribute->GetModule()->GetRootModule(), itr->get()->GetAsHistory(), (boost::_tformat(_T("Preprocessed (%1%) from %2%.")) % PREPROCESS_LABEL[PREPROCESS_SAVE] % m_attribute->GetQualifiedLabel()).str().c_str(), true);
 			m_migrator->Start();
-			m_migrator->Join();
-			SendMessage(CWM_SUBMITDONE, Dali::WUActionCheck, (LPARAM)&errors);
-			GetIMainFrame()->Send_RefreshRepositoryWindow(m_attribute->GetModule());
-			GetIMainFrame()->SyncTOC(m_attribute->GetQualifiedLabel(), m_attribute->GetType());
+			SetTimer(0, 200);
 		}
 		return true;
 	}
 	return false;
 }
 
+void CAttributeDlg::OnTimer(UINT_PTR nIDEvent)
+{
+	if (m_migrator->GetActiveMigrationCount() == 0)
+	{
+		KillTimer(0);
+		GetIMainFrame()->Send_RefreshRepositoryWindow(m_attribute->GetModule());
+		GetIMainFrame()->SyncTOC(m_attribute->GetQualifiedLabel(), m_attribute->GetType());
+	}
+}
 //bool CBuilderDlg::DoFileSave(const CString & sPathName) 
 //{
 //  Help Alligning with BuilderDlg COmpare

--- a/eclide/EclDlgAttribute.h
+++ b/eclide/EclDlgAttribute.h
@@ -39,6 +39,7 @@ public:
 	BEGIN_MSG_MAP(thisClass)
 		MSG_WM_INITDIALOG(OnInitDialog)
 		MESSAGE_HANDLER_EX(CWM_INITIALIZE, OnInitialize)
+		MSG_WM_TIMER(OnTimer)
 
 		COMMAND_ID_HANDLER_EX(ID_ECL_SYNCTOC, OnEclSyncToc)
 		COMMAND_ID_HANDLER_EX(ID_ECL_GOTO, OnEclGoto)
@@ -58,6 +59,7 @@ public:
 
 	LRESULT OnInitDialog(HWND hWnd, LPARAM lParam);
 	LRESULT OnInitialize(UINT uMsg, WPARAM wParam, LPARAM lParam);
+	void OnTimer(UINT_PTR nIDEvent);
 	void OnEclSyncToc(UINT /*uNotifyCode*/, int /*nID*/, HWND /*hWnd*/);
 	void OnEclGoto(UINT /*uNotifyCode*/, int /*nID*/, HWND /*hWnd*/);
 	void OnEclGotoSyncToc(UINT /*uNotifyCode*/, int /*nID*/, HWND /*hWnd*/);

--- a/eclide/EclDlgBuilder.cpp
+++ b/eclide/EclDlgBuilder.cpp
@@ -64,6 +64,7 @@ bool CBuilderDlg::DoSave(bool attrOnly)
 		IAttributeVector attrs;
 		Dali::CEclExceptionVector errors;
 		m_attribute->PreProcess(PREPROCESS_SAVE, NULL, attrs, errors);
+		SendMessage(CWM_SUBMITDONE, Dali::WUActionCheck, (LPARAM)&errors);
 		if (attrs.size())
 		{
 			if (!m_migrator)
@@ -73,10 +74,7 @@ bool CBuilderDlg::DoSave(bool attrOnly)
 			for(IAttributeVector::const_iterator itr = attrs.begin(); itr != attrs.end(); ++itr)
 				m_migrator->AddToRep(m_attribute->GetModule()->GetRootModule(), itr->get()->GetAsHistory(), (boost::_tformat(_T("Preprocessed (%1%) from %2%.")) % PREPROCESS_LABEL[PREPROCESS_SAVE] % m_attribute->GetQualifiedLabel()).str().c_str(), true);
 			m_migrator->Start();
-			m_migrator->Join();
-			SendMessage(CWM_SUBMITDONE, Dali::WUActionCheck, (LPARAM)&errors);
-			GetIMainFrame()->Send_RefreshRepositoryWindow(m_attribute->GetModule());
-			GetIMainFrame()->SyncTOC(m_attribute->GetQualifiedLabel(), m_attribute->GetType());
+			SetTimer(0, 200);
 		}
 		return true;
 	}
@@ -87,6 +85,15 @@ bool CBuilderDlg::DoSave(bool attrOnly)
 	return false;
 }
 
+void CBuilderDlg::OnTimer(UINT_PTR nIDEvent)
+{
+	if (m_migrator->GetActiveMigrationCount() == 0)
+	{
+		KillTimer(0);
+		GetIMainFrame()->Send_RefreshRepositoryWindow(m_attribute->GetModule());
+		GetIMainFrame()->SyncTOC(m_attribute->GetQualifiedLabel(), m_attribute->GetType());
+	}
+}
 bool CBuilderDlg::DoFileSaveAs() 
 {
 	CFileDialogEx wndFileDialog(FALSE, _T(".ecl"), m_path, OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT, szEclSaveFilter, m_hWnd);

--- a/eclide/EclDlgBuilder.h
+++ b/eclide/EclDlgBuilder.h
@@ -130,6 +130,7 @@ public:
 		MESSAGE_HANDLER_EX(CWM_INITIALIZE, OnInitialize)
 		MSG_WM_DESTROY(OnDestroy)
 		MSG_WM_SIZE(OnSize)
+		MSG_WM_TIMER(OnTimer)
 
 		MESSAGE_HANDLER_EX(BUM_REFRESHQUEUECLUSTER, OnRefreshQueueCluster)
 
@@ -180,6 +181,7 @@ public:
 	LRESULT OnInitialize(UINT uMsg, WPARAM wParam, LPARAM lParam);
 	void OnDestroy();
 	void OnSize(UINT nType, CSize size);
+	void OnTimer(UINT_PTR nIDEvent);
 	LRESULT OnRefreshQueueCluster(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
 	void OnFileSaveAs(UINT /*uNotifyCode*/, int /*nID*/, HWND /*hWnd*/);


### PR DESCRIPTION
Salt auto import hangs during save of .salt file.
This happens when the imported attributes already exist and are visible in the Attribute Tree.
This regressions was caused when "refresh open windows on import" was implemented

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
