### PR TITLE
IDE-226 Missing Tab Tooltip on Attribute Window.

### DIFF
--- a/eclide/ChildAttributeFrame.cpp
+++ b/eclide/ChildAttributeFrame.cpp
@@ -160,7 +160,10 @@ public:
 
 	const TCHAR * GetTabTip(std::_tstring & tabTip)
 	{
-		tabTip = GetPath();
+		if (CComPtr<IAttribute> attr = m_dlgview.GetAttribute())
+		{
+			tabTip = attr->GetQualifiedLabel();
+		}
 		return tabTip.c_str();
 	}
 

--- a/eclide/WtlMDIChildFrame.h
+++ b/eclide/WtlMDIChildFrame.h
@@ -222,7 +222,6 @@ afx_msg LRESULT CWtlMDIChildFrame<ViewT>::OnCloseAllClearAutoSave(WPARAM wParam,
 template<typename ViewT>
 afx_msg LRESULT CWtlMDIChildFrame<ViewT>::OnGetTooltip(WPARAM wParam, LPARAM lParam)
 {
-
 	std::_tstring * tooltip = (std::_tstring *)wParam;
 	if (tooltip) 
 	{


### PR DESCRIPTION
If using the remote repository, attribute windows have no tooltip.

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
