### PR TITLE
IDE-248 Persisted plugin is marked as dirty on restore

### DIFF
--- a/clib/Util.cpp
+++ b/clib/Util.cpp
@@ -797,6 +797,7 @@ bool GetPluginECL(const std::_tstring & pluginPath, std::_tstring & ecl)
 				if (p(&info))
 				{
 					ecl = CA2T(info.ECL, CP_UTF8);
+					TidyCRLF(ecl);
 					retVal = true;
 				}
 			}


### PR DESCRIPTION
If the user restarts the IDE with the ECL from a plugin visible, it shows as
"dirty" when the IDE restarts.

Fixes IDE-248

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
