### PR TITLE
IDE-277 ESDL Attributes Have Blank History

### DIFF
--- a/comms/AttributeHistory.cpp
+++ b/comms/AttributeHistory.cpp
@@ -196,7 +196,7 @@ IAttributeHistory * CreateAttributeHistory(const IRepository* rep, const std::_t
 	return attr;
 }
 #else
-IAttributeHistory * CreateAttributeHistory(const IRepository *rep, const ns2__ECLAttribute * data)
+IAttributeHistory * CreateAttributeHistory(const IRepository *rep, IAttributeType * type, const ns2__ECLAttribute * data)
 {
 	std::_tstring moduleName;
 	SAFE_ASSIGN(moduleName, data->ModuleName);
@@ -207,13 +207,11 @@ IAttributeHistory * CreateAttributeHistory(const IRepository *rep, const ns2__EC
 	if (name.empty())
 		return NULL;
 
-	std::_tstring type;
-	SAFE_ASSIGN(type, data->Type);
 	unsigned int version = 0;
 	SAFE_ASSIGN(version, data->Version);
 	bool isSandbox = false;
 	SAFE_ASSIGN(isSandbox, data->IsSandbox);
-	CAttributeHistory * attr = CreateAttributeHistoryRaw(rep, moduleName.c_str(), name.c_str(), CreateIAttributeType(type), version, isSandbox);
+	CAttributeHistory * attr = CreateAttributeHistoryRaw(rep, moduleName.c_str(), name.c_str(), type, version, isSandbox);
 	ATLASSERT(attr);
 	attr->Update(data);
 	return attr;

--- a/comms/Repository.cpp
+++ b/comms/Repository.cpp
@@ -27,7 +27,7 @@ PasswordCacheT g_passwordCache;
 IModule * CreateModule(const IRepository *rep, const ns2__ECLModule *data, bool noBroadcast=false);
 IModule * CreateModulePlaceholder(const IRepository *rep, const std::_tstring &label);
 IAttribute * CreateAttribute(const IRepository *rep, const ns2__ECLAttribute * data, bool noBroadcast=false);
-IAttributeHistory * CreateAttributeHistory(const IRepository *rep, const ns2__ECLAttribute * data);
+IAttributeHistory * CreateAttributeHistory(const IRepository *rep, IAttributeType * type, const ns2__ECLAttribute * data);
 
 #define ESP_EXCEPTION_LOG3(T) CReportingGSoapEspException<ns2__ArrayOfEspException> exceptions(T, __FILE__, __LINE__)
 
@@ -523,7 +523,7 @@ public:
 			{
 				if (response.outAttribute->ModuleName && response.outAttribute->Name)	//  Succeeded but no attribute.
 				{
-					CComPtr<IAttributeHistory> attribute = CreateAttributeHistory(this, response.outAttribute);
+					CComPtr<IAttributeHistory> attribute = CreateAttributeHistory(this, type, response.outAttribute);
 					return attribute;
 				}
 			}
@@ -620,7 +620,7 @@ public:
 			{
 				for(std::size_t i = 0; i < response.outAttributes->ECLAttribute.size(); ++i)
 				{
-					StlLinked<IAttributeHistory> attribute = CreateAttributeHistory(this, response.outAttributes->ECLAttribute[i]);
+					StlLinked<IAttributeHistory> attribute = CreateAttributeHistory(this, type, response.outAttributes->ECLAttribute[i]);
 					attributes.push_back(attribute);
 				}
 			}


### PR DESCRIPTION
The "ECL" text portion of a selected historic item was blank.

Fixes IDE-277

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
