### PR TITLE
IDE-281 Debugger crashes after Layout finishes

### DIFF
--- a/GraphViewCtl/GraphViewCanvas.cpp
+++ b/GraphViewCtl/GraphViewCanvas.cpp
@@ -108,6 +108,7 @@ void CGraphViewCanvas::OnClear()
 	clib::recursive_mutex::scoped_lock lock(m_mutex);
 	Stop();
 	SetRedraw(false);
+	ClearSelected();
 
 	CBuildingEdgeVisibility building(m_buildingEdgeVisibility);
 	RemoveSubgraph(m_graph);
@@ -3826,6 +3827,7 @@ void CGraphViewCanvas::OnDestroy()
 	m_tooltip.RemoveAllTools();
 	if (m_tooltip.IsWindow())
 		m_tooltip.DestroyWindow();
+	ClearSelected();
 }
 
 void CGraphViewCanvas::OnHScroll(int scrollRequest, short scrollPos, HWND hWnd)

--- a/GraphViewCtl/neato.cpp
+++ b/GraphViewCtl/neato.cpp
@@ -1014,7 +1014,8 @@ bool CGraphATTLayoutImpl::pulse2(const GraphTypes::RectF & extent)
 	std::_tstring formatbuf;
 	RectF bbox;
 
-	std::string svgResult;
+	IString * svgResult = createIString();
+	svgResult->AddRef();
 	bool retVal = false;
 	std::stringstream dotStream;
 	{
@@ -1074,11 +1075,12 @@ bool CGraphATTLayoutImpl::pulse2(const GraphTypes::RectF & extent)
 		//	if (static_cast<bool>(GetIConfig(QUERYBUILDER_CFG)->Get(GLOBAL_DEBUG_LOGRESULTXML))==true)
 		{
 			std::ofstream file("c:\\temp\\neato_cpp.xml");
-			file << svgResult;
+			file << svgResult->c_str();
 		}
 #endif
-		std::_tstring content = CA2T(svgResult.c_str(), CP_UTF8);
+		std::_tstring content = CA2T(svgResult->c_str(), CP_UTF8);
 		mergeSVG(content.c_str(), m_graph, m_mode);
+		svgResult->Release();
 	}
 	return retVal;
 }


### PR DESCRIPTION
Could also crash if closing window with items selected.

Fixes IDE-281

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
