### PR TITLE
IDE-267 Graph Windows/ECL Definitions List Broken

### DIFF
--- a/EclLib/DefinitionParser.cpp
+++ b/EclLib/DefinitionParser.cpp
@@ -51,15 +51,30 @@ struct definition_parser : public boost::spirit::classic::grammar<definition_par
 
 			first =
 				(
-				def_string	= !(mod_attr) >> confix_p('(', row_col, ')'),
+				def_string	= ( builder_def				[ASSIGN(type, ParsedDefinition::BUILDER)]
+							  | remote_def				[ASSIGN(type, ParsedDefinition::REMOTE)]
+							  | local_def				[ASSIGN(type, ParsedDefinition::LOCAL)]
+							  ), 
+
+				builder_def	= confix_p('(', row_col, ')'),
+
+				local_def	= folder >> file,
+
+				folder		= (+(anychar_p - file))			[ASSIGNSTR(module, arg1, arg2)],
+
+				file		= (+(anychar_p - (ch_p('\\') | '(')))	[ASSIGNSTR(attribute, arg1, arg2)]
+							>> confix_p('(', row_col, ')'),
+
+				remote_def	= mod_attr >> confix_p('(', row_col, ')'),
 
 				mod_attr	= module >> '.' >> attribute,
 
-				module		= identifier [ASSIGNSTR(module, arg1, arg2)],
+				module		= identifier					[ASSIGNSTR(module, arg1, arg2)],
 
-				attribute	= identifier [ASSIGNSTR(attribute, arg1, arg2)],
+				attribute	= identifier					[ASSIGNSTR(attribute, arg1, arg2)],
 
-				row_col		= uint_p [ASSIGN(row, arg1)] >> !(',' >> uint_p [ASSIGN(col, arg1)]),
+				row_col		=  uint_p						[ASSIGN(row, arg1)]
+							>> !(',' >> uint_p				[ASSIGN(col, arg1)]),
 
 				identifier = 
 					nocase_d
@@ -73,11 +88,16 @@ struct definition_parser : public boost::spirit::classic::grammar<definition_par
 #undef ASSIGN
 		}
 		boost::spirit::classic::subrule<0> def_string;
-		boost::spirit::classic::subrule<1> mod_attr;
-		boost::spirit::classic::subrule<2> module;
-		boost::spirit::classic::subrule<3> attribute;
-		boost::spirit::classic::subrule<4> row_col;
-		boost::spirit::classic::subrule<5> identifier;
+		boost::spirit::classic::subrule<1> local_def;
+		boost::spirit::classic::subrule<2> builder_def;
+		boost::spirit::classic::subrule<3> remote_def;
+		boost::spirit::classic::subrule<4> folder;
+		boost::spirit::classic::subrule<5> file;
+		boost::spirit::classic::subrule<6> mod_attr;
+		boost::spirit::classic::subrule<7> module;
+		boost::spirit::classic::subrule<8> attribute;
+		boost::spirit::classic::subrule<9> row_col;
+		boost::spirit::classic::subrule<10> identifier;
 		boost::spirit::classic::rule<scannerT> first;
 		const boost::spirit::classic::rule<scannerT>& start() const
 		{
@@ -94,10 +114,33 @@ bool DefinitionToLocation(const std::_tstring & def_string, ParsedDefinition & r
 
 	definition_parser definition_p;
     ParsedDefinition result1;
-	if (boost::spirit::classic::parse(def_string.c_str(), definition_p[phoenix::var(result1) = phoenix::arg1]).full)
+	boost::spirit::classic::parse_info<std::_tstring::const_iterator> parse_result = boost::spirit::classic::parse(def_string.begin(), def_string.end(), definition_p[phoenix::var(result1) = phoenix::arg1], space_p);
+	if (parse_result.full)
 	{
 		result = result1;
 		return true;
 	}
+#ifdef _DEBUG
+	else
+	{
+		std::_tstring parsed(def_string.begin(), parse_result.stop);
+	}
+#endif
 	return false;
 }
+
+#ifdef _DEBUG
+class _DefinitionToLocationTest 
+{ 
+public:
+	_DefinitionToLocationTest() 
+	{
+		ParsedDefinition pd;
+		ATLASSERT(DefinitionToLocation(_T("(1,2)"), pd));
+		ATLASSERT(DefinitionToLocation(_T("c:\\temp\\test.ecl(2,3)"), pd));
+		ATLASSERT(DefinitionToLocation(_T("c:\\temp\\test123.ecl(4,5)"), pd));
+		ATLASSERT(DefinitionToLocation(_T("a.b(6,7)"), pd));
+		//ATLASSERT(!DefinitionToLocation(_T("a.b.c(8,9)"), pd));
+	}
+} DefinitionToLocationTest;
+#endif

--- a/EclLib/DefinitionParser.h
+++ b/EclLib/DefinitionParser.h
@@ -5,6 +5,14 @@
 class ParsedDefinition
 {
 public:
+	enum TYPE
+	{
+		 UNKNOWN,
+		 BUILDER,
+		 LOCAL,
+		 REMOTE,
+		 LAST
+	} type;
 	std::_tstring module;
 	std::_tstring attribute;
 	unsigned int row;
@@ -26,7 +34,7 @@ public:
 
 	bool IsBuilder() const
 	{
-		return module.size() == 0 && attribute.size() == 0;
+		return type == BUILDER;
 	}
 };
 

--- a/eclide/GraphView2.h
+++ b/eclide/GraphView2.h
@@ -188,7 +188,7 @@ public:
 		ATLASSERT(retVal);
 		CComSafeArray<VARIANT> vertices = vaResult.parray;
 		for(ULONG i = 0; i < vertices.GetCount(); ++i)
-			results->Add(CUniqueID(guidDefault, XGMML_CAT_EDGE, boost::lexical_cast<std::_tstring>(vertices.GetAt(i).lVal)));
+			results->Add(CUniqueID(guidDefault, XGMML_CAT_VERTEX, boost::lexical_cast<std::_tstring>(vertices.GetAt(i).lVal)));	//  UniqueID's ID is the internal int...
 		ATLASSERT(retVal);
 	}
 
@@ -198,10 +198,15 @@ public:
 		ATLASSERT(retVal);
 	}
 
-	int GetItem(const CUniqueID& uid)
+	int UniqueIDToInternalID(const CUniqueID& uid)
+	{
+		return boost::lexical_cast<int>(uid.GetID());
+	}
+
+	int GetItem(const std::_tstring globalID)
 	{
 		CComVariant vaResult;
-		bool retVal = InvokeScript(_T("getItem"), uid.GetID(), vaResult);
+		bool retVal = InvokeScript(_T("getItem"), globalID, vaResult);
 		ATLASSERT(retVal);
 		return vaResult.intVal;
 	}
@@ -223,12 +228,12 @@ public:
 
 	void CenterGraphItem(const CUniqueID& uid, bool scaleToFit = true)
 	{
-		CenterGraphItem(GetItem(uid), scaleToFit);
+		CenterGraphItem(UniqueIDToInternalID(uid), scaleToFit);
 	}
 
 	void CenterVertex(const CUniqueID& uid, bool scaleToFit = true)
 	{
-		CenterGraphItem(GetItem(uid), scaleToFit);
+		CenterGraphItem(UniqueIDToInternalID(uid), scaleToFit);
 	}
 
 	IGraphSubgraph* GetSubgraph(const CUniqueID& uid)


### PR DESCRIPTION
The ECL Definition Window is missing information for local files.
Clicking on items in the list would no center on the correct item.

Fixes IDE-267

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
