### PR TITLE
IDE-291 Open attribute in builder windows, causes warning dialog

### DIFF
--- a/eclide/ChildBuilderFrame.cpp
+++ b/eclide/ChildBuilderFrame.cpp
@@ -1096,7 +1096,7 @@ HWND OpenBuilderMDI(CMainFrame* pFrame, IAttribute *src, IWorkspaceItem * worksp
 		pChild = new CChildBuilderFrm(workspaceItem);
 		CreateNewChild(pFrame, pChild, IDR_BUILDERWINDOW, _T("builder.ecl"));
 		pChild->m_view->SetAttribute(src);
-		pChild->m_view->SetEcl(src->GetText(), true);
+		pChild->m_view->SetEcl(src->GetText(true, true), true);
 	}
 	return ((CMDIChildWnd *)pChild)->GetSafeHwnd();
 }


### PR DESCRIPTION
Remote Repository:  Opening an attribute in a builder window, causes the "file
has changed on disk" warning to instantly appear.

Fixes IDE-291

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
