### PR TITLE
IDE-318 Saving ECL causes syntax window to popup

### DIFF
--- a/wlib/EclCommand.h
+++ b/wlib/EclCommand.h
@@ -612,7 +612,7 @@ public:
 			syntaxStatus += warnCount;
 			syntaxStatus += _T(" Warnings");
 			m_eclSlot->PostStatus(syntaxStatus);
-			m_eclSlot->RefreshSyntax(m_ecl, 0, true);
+			m_eclSlot->RefreshSyntax(m_ecl, 0, err || warn);
 		}
 		return 0;
 	}


### PR DESCRIPTION
Changed to only popup when there are errors or warnings, which can happen with
plugins (salt, kel etc.).

Fixes IDE-318

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
