### PR TITLE
IDE-348 Add --nosourcepath for temporary files

### DIFF
--- a/comms/EclCC.cpp
+++ b/comms/EclCC.cpp
@@ -272,6 +272,11 @@ public:
 	{
 		clib::recursive_mutex::scoped_lock proc(m_mutex);
 		hasErrors = false;
+
+		std::_tstring command = _T("\"");
+		command += m_compilerFile;
+		command += _T("\"");
+
 		CAtlTemporaryFile temp;
 		std::_tstring sourcePath;
 		if (_module.empty() && _attribute.empty() && path.empty())
@@ -281,6 +286,7 @@ public:
 			std::string necl = CT2A(ecl.c_str(), CP_UTF8);
 			temp.Write(necl.c_str(), necl.length());
 			temp.HandsOff();
+			command += _T(" --nosourcepath");
 		}
 		else if (path.empty())
 		{
@@ -291,9 +297,6 @@ public:
 			sourcePath = path;
 		}
 
-		std::_tstring command = _T("\"");
-		command += m_compilerFile;
-		command += _T("\"");
 		if (!m_arguments.empty())
 		{
 			command += _T(" ");


### PR DESCRIPTION
If the IDE is calling eclcc with a temporary file, it should use the
--nosourcepath compiler argument.

Fixes IDE-348

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
