### PR TITLE
IDE-356 Builder window support for 'other' ECL generation languages

### DIFF
--- a/comms/Attribute.cpp
+++ b/comms/Attribute.cpp
@@ -481,13 +481,10 @@ public:
 	int PreProcess(PREPROCESS_TYPE action, const TCHAR * overrideEcl, IAttributeVector & attrs, Dali::CEclExceptionVector & errs) const
 	{
 		clib::recursive_mutex::scoped_lock proc(m_mutex);
-		boost::filesystem::path folder, path;
-		GetProgramFolder(folder);
-		folder /= "plugin";
 		std::string batchFile = CT2A(GetType()->GetRepositoryCode());
 		batchFile += ".bat";
-		path = folder / batchFile;
-		if (boost::filesystem::exists(path))
+		boost::filesystem::path folder;
+		if (locatePlugin(batchFile, folder)) 
 		{
 			//  Hack For ESDL PrePreProcessing  ---
 			if (boost::algorithm::equals(batchFile.c_str(), "esdl.bat"))

--- a/comms/AttributeType.h
+++ b/comms/AttributeType.h
@@ -10,6 +10,7 @@ enum PREPROCESS_TYPE
 	PREPROCESS_CALCINCLUDES, 
 	PREPROCESS_SAVE, 
 	PREPROCESS_COMMIT, 
+	PREPROCESS_SUBMIT, 
 	PREPROCESS_LAST
 };
 
@@ -21,6 +22,7 @@ const TCHAR * const PREPROCESS_LABEL[] =
 	_T("CalcIncludes"),
 	_T("Save"),
 	_T("Commit"),
+	_T("Submit"),
 	_T("Last")
 };
 

--- a/comms/EclCC.cpp
+++ b/comms/EclCC.cpp
@@ -286,7 +286,8 @@ public:
 			std::string necl = CT2A(ecl.c_str(), CP_UTF8);
 			temp.Write(necl.c_str(), necl.length());
 			temp.HandsOff();
-			command += _T(" --nosourcepath");
+			if (GetBuild()->GetMajor() >= 5)
+				command += _T(" --nosourcepath");
 		}
 		else if (path.empty())
 		{

--- a/eclide/ChildBuilderFrame.cpp
+++ b/eclide/ChildBuilderFrame.cpp
@@ -356,7 +356,7 @@ public:
 		ExecEcl(Dali::WUActionRun, ecl, m_dlgview.IsScheduled(), m_dlgview.IsLabeled(), true);
 	}
 
-	void ExecEcl(Dali::WUAction action, const CString &ecl, bool isScheduled=false, bool isLabeled=false, bool isDebug=false, bool isDrilldown=false)
+	void ExecEcl(Dali::WUAction action, const CString &_ecl, bool isScheduled=false, bool isLabeled=false, bool isDebug=false, bool supressPath=false)
 	{
 		if (CComPtr<IEclCC> eclcc = CreateIEclCC())
 		{
@@ -387,7 +387,20 @@ public:
 		if (CComPtr<IAttribute> attr = m_dlgview.GetAttribute())
 			attrQualifiedLabel = attr->GetQualifiedLabel(true);
 
-		result->ExecEcl(m_dlgview.GetCluster(), m_dlgview.GetQueue(), action, attrQualifiedLabel.c_str(), ecl, isDrilldown ? _T("") : m_dlgview.GetPath(), when.c_str(), label, m_dlgview.GetResultLimit(), debugStr.c_str(), m_dlgview.IsArchive(), m_dlgview.GetMaxRuntime(), isDebug);
+		CString ecl = _ecl;
+		CComPtr<IAttribute> attr = m_dlgview.GetAttribute();
+		if (attr != NULL && attr->GetType() != CreateIAttributeECLType())
+		{
+			IAttributeVector attrs;
+			Dali::CEclExceptionVector errors;
+			attr->PreProcess(PREPROCESS_SUBMIT, _ecl, attrs, errors);
+			if (!attrs.empty())
+			{
+				ecl = attrs[0]->GetText(false, true);
+			}
+			supressPath = true;
+		}
+		result->ExecEcl(m_dlgview.GetCluster(), m_dlgview.GetQueue(), action, attrQualifiedLabel.c_str(), ecl, supressPath ? _T("") : m_dlgview.GetPath(), when.c_str(), label, m_dlgview.GetResultLimit(), debugStr.c_str(), m_dlgview.IsArchive(), m_dlgview.GetMaxRuntime(), isDebug);
 		GetIConfig(QUERYBUILDER_CFG)->Set(GLOBAL_QUEUE, m_dlgview.GetQueue());
 		GetIConfig(QUERYBUILDER_CFG)->Set(GLOBAL_CLUSTER, m_dlgview.GetCluster());
 		PostStatus(_T(""));

--- a/eclide/EclDlgAttribute.cpp
+++ b/eclide/EclDlgAttribute.cpp
@@ -92,13 +92,14 @@ void CAttributeDlg::DoCheckSyntax()
 	CString cluster(GetIConfig(QUERYBUILDER_CFG)->Get(GLOBAL_CLUSTER));
 	CString module(m_attribute->GetModuleQualifiedLabel());
 	CString attribute(m_attribute->GetLabel());
+
+	if (CComPtr<IEclCC> eclcc = CreateIEclCC())
+	{
+		if (!DoSave(false))
+			return;
+	}
 	if (m_attribute->GetType() == CreateIAttributeECLType())
 	{
-		if (CComPtr<IEclCC> eclcc = CreateIEclCC())
-		{
-			if (!DoSave(false))
-				return;
-		}
 		clib::thread run(__FUNCTION__, boost::bind(&EclCheckSyntax, this, ecl, cluster, module, attribute, _T(""), _T(""), false, false));
 	}
 	else

--- a/eclide/EclDlgBuilder.cpp
+++ b/eclide/EclDlgBuilder.cpp
@@ -425,7 +425,18 @@ void CBuilderDlg::DoCheckSyntax()
 		if (!m_path.IsEmpty() && IsDirty()) 
 			DoFileSave(m_path);
 	}
-	clib::thread run(__FUNCTION__, boost::bind(&EclCheckSyntax, this, ecl, cluster, CString(), CString(), m_path, m_debug, false, m_noCommonPrivateAttributes));
+
+	if (m_attribute->GetType() == CreateIAttributeECLType())
+	{
+		clib::thread run(__FUNCTION__, boost::bind(&EclCheckSyntax, this, ecl, cluster, CString(), CString(), m_path, m_debug, false, m_noCommonPrivateAttributes));
+	}
+	else
+	{
+		IAttributeVector attrs;
+		Dali::CEclExceptionVector errors;
+		m_attribute->PreProcess(PREPROCESS_SYNTAXCHECK, ecl, attrs, errors);
+		SendMessage(CWM_SUBMITDONE, Dali::WUActionCheck, (LPARAM)&errors);
+	}
 }
 
 void CBuilderDlg::DoCheckComplexity()


### PR DESCRIPTION
Added new PreProcessor command "Submit".
Auto locate plugins that have been installed as siblings.
Do not add --nosource flag if compiler is < 5.0

Fixes IDE-356

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
