### PR TITLE
IDE-336 Open editors lose their accelerator table if the user displays a...

### DIFF
--- a/eclide/mainfrm.cpp
+++ b/eclide/mainfrm.cpp
@@ -522,11 +522,17 @@ void CMainFrame::SetWorkspaceMode(WORKSPACE workspaceMode)
 		{
 			SetRedraw(FALSE);
 			theApp.EnableLoadWindowPlacement(FALSE);
-			//  Prevent LoadState from replacing the accelerator table  ---
-			CKeyboardManager * tmp = afxKeyboardManager;
-			afxKeyboardManager = NULL;
 			theApp.LoadState(this, newSection);
-			afxKeyboardManager = tmp;
+
+			CWnd* pWndChild=CWnd::FromHandle(m_hWndMDIClient); 
+			pWndChild=pWndChild->GetWindow(GW_CHILD); 
+			while(pWndChild) 
+			{ 
+				if (pWndChild->IsKindOf(RUNTIME_CLASS(CMDIChildWnd)))
+					((CMDIChildWnd*)pWndChild)->SetHandles(NULL, this->m_hAccelTable);
+				pWndChild=pWndChild->GetWindow(GW_HWNDNEXT); 
+			} 
+
 			SetRedraw(TRUE);
 			RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ERASE | RDW_ALLCHILDREN);
 			AdjustClientArea();


### PR DESCRIPTION
...n IDE Graph

Fixes IDE-336

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com

Conflicts:
    eclide/mainfrm.cpp
