### PR TITLE
IDE-367 Crash on Syntax Check

### DIFF
--- a/eclide/EclDlgBuilder.cpp
+++ b/eclide/EclDlgBuilder.cpp
@@ -426,7 +426,7 @@ void CBuilderDlg::DoCheckSyntax()
 			DoFileSave(m_path);
 	}
 
-	if (m_attribute->GetType() == CreateIAttributeECLType())
+	if (!m_attribute || m_attribute->GetType() == CreateIAttributeECLType())
 	{
 		clib::thread run(__FUNCTION__, boost::bind(&EclCheckSyntax, this, ecl, cluster, CString(), CString(), m_path, m_debug, false, m_noCommonPrivateAttributes));
 	}


### PR DESCRIPTION
IDE crashes on syntax check if builder window has no attribute associated with
it (it has never been saved for example).

Fixes IDE-367

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
