### PR TITLE
IDE-392 Add Client ID and Version to the ESP Logs

### DIFF
--- a/comms/gSoapUtil.h
+++ b/comms/gSoapUtil.h
@@ -2,6 +2,7 @@
 
 #include "SoapUtil.h"
 #include "Global.h"
+#include "..\config.h"
 
 //  ===========================================================================
 void ResetNamespace(IConfig * config);
@@ -79,6 +80,8 @@ private:
 	void Init(const std::_tstring & url, const std::_tstring & user, const std::_tstring & password, int _connect_timeout = 0, int _send_timeout = 0, int _recv_timeout = RECV_TIMEOUT)
 	{
 		m_url = CT2A(url.c_str());
+		m_url += "?ClientID=ECLIDE-";
+		m_url += BUILD_TAG;
 		m_user = CT2A(user.c_str());
 		m_password = CT2A(password.c_str());
 


### PR DESCRIPTION
Adding a parameter to the SOAP URL will force the Client ID and version into the ESP logs.

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
