### PR TITLE
IDE-398 Error message when plugin (KEL, SALT, etc) is not found

### DIFF
--- a/comms/AttributeImpl.h
+++ b/comms/AttributeImpl.h
@@ -5,6 +5,7 @@
 #include "cmdProcess.h"
 #include "EclErrorParser.h"
 #include <UtilFilesystem.h>
+#include "logger.h"
 
 class CAttributeBase : public clib::CLockableUnknown
 {
@@ -46,6 +47,7 @@ public:
 				}
 			}
 		}
+		_DBGLOG(LEVEL_WARNING, (boost::format("Plugin not found - %1%") % batchFile).str().c_str());
 		return false;
 	}
 


### PR DESCRIPTION
Fixes IDE-398

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
