### PR TITLE
IDE-394 Repository tree refresh issue

### DIFF
--- a/comms/DiskAttribute.cpp
+++ b/comms/DiskAttribute.cpp
@@ -494,10 +494,10 @@ CDiskAttribute * CreateDiskAttributeRaw(const IRepository *rep, const TCHAR* mod
 	return DiskAttributeCache.Get(new CDiskAttribute(rep, module, label, type, path, version, sandboxed));
 }
 
-//IAttribute * CreateDiskAttribute(const IRepository *rep, const TCHAR* module, const TCHAR* label, unsigned version, bool sandboxed)
-//{
-//	return CreateDiskAttributeRaw(rep, module, label, version, sandboxed, false);
-//}
+IAttribute * CreateDiskAttribute(const IRepository *rep, const TCHAR* module, const TCHAR* label, IAttributeType * type, const boost::filesystem::wpath & path)
+{
+	return CreateDiskAttributeRaw(rep, module, label, type->GetRepositoryCode(), path, 0, false);
+}
 
 IAttribute * CreateDiskAttributePlaceholder(const IRepository *rep, const TCHAR* module, const TCHAR* label, const TCHAR* type, const boost::filesystem::wpath & path)
 {

--- a/comms/DiskModule.cpp
+++ b/comms/DiskModule.cpp
@@ -528,9 +528,9 @@ public:
 		return on_refresh.connect(s); 
 	}
 
-	void Refresh()
+	void Refresh(REFRESH_MODULE refreshType = REFRESH_MODULE_UNKNOWN)
 	{
-		on_refresh(this);
+		on_refresh(this, refreshType);
 	}
 };
 

--- a/comms/DiskRepository.cpp
+++ b/comms/DiskRepository.cpp
@@ -17,6 +17,7 @@ namespace algo = boost::algorithm;
 IModule * CreateDiskModule(const IRepository *rep, const std::_tstring &label, const boost::filesystem::wpath & path, bool noBroadcast = false);
 IAttribute * CreateDiskAttribute(const IRepository *rep, const std::_tstring &moduleLabel, const std::_tstring &label, const std::_tstring &type, const boost::filesystem::wpath & path, const std::_tstring & ecl, bool noBroadcast);
 IAttribute * GetDiskAttribute(const IRepository *rep, const TCHAR* module, const TCHAR* label, IAttributeType * type, unsigned version, bool sandboxed);
+IAttribute * CreateDiskAttribute(const IRepository *rep, const TCHAR* module, const TCHAR* label, IAttributeType * type, const boost::filesystem::wpath & path);
 IAttribute * CreateDiskAttributePlaceholder(const IRepository *rep, const TCHAR* module, const TCHAR* label, const TCHAR* type, const boost::filesystem::wpath & path);
 //IAttributeHistory * CreateAttributeHistory(const IRepository *rep, const std::_tstring &moduleLabel, const std::_tstring & label, const ECLAttribute * data);
 void ClearDiskAttributeCache();
@@ -99,6 +100,12 @@ private:
 					std::_tstring attrLabel = stringToWString(boost::filesystem::basename(relativePath)).c_str();
 					std::_tstring ecl;
 					CComPtr<IAttribute> attr = GetDiskAttribute((IRepository *)self->m_repository, moduleLabel.c_str(), attrLabel.c_str(), CreateIAttributeType(type), 0, false);
+					if (!attr) 
+					{
+						attr = CreateDiskAttribute((IRepository *)self->m_repository, moduleLabel.c_str(), attrLabel.c_str(), CreateIAttributeType(type), fullPath);
+						if (attr)
+							attr->GetModule()->Refresh(REFRESH_MODULE_CHILDADDED);
+					}
 					if (attr)
 						attr->GetText();
 				}

--- a/comms/ModFileModule.cpp
+++ b/comms/ModFileModule.cpp
@@ -198,9 +198,9 @@ public:
 		return on_refresh.connect(s); 
 	}
 
-	void Refresh()
+	void Refresh(REFRESH_MODULE refreshType = REFRESH_MODULE_UNKNOWN)
 	{
-		on_refresh(this);
+		on_refresh(this, refreshType);
 	}
 };
 

--- a/comms/Module.cpp
+++ b/comms/Module.cpp
@@ -270,9 +270,9 @@ public:
 		return on_refresh.connect(s); 
 	}
 
-	void Refresh()
+	void Refresh(REFRESH_MODULE refreshType = REFRESH_MODULE_UNKNOWN)
 	{
-		on_refresh(this);
+		on_refresh(this, refreshType);
 	}
 };
 

--- a/comms/Module.h
+++ b/comms/Module.h
@@ -11,7 +11,13 @@ typedef StlLinked<IModule> IModuleAdapt;
 typedef std::vector<IModuleAdapt> IModuleVector;
 typedef std::set<IModuleAdapt, IModuleCompare> IModuleSet;
 
-typedef boost::signal<void(IModule *)> module_refresh_signal_type;
+enum REFRESH_MODULE
+{
+	REFRESH_MODULE_UNKNOWN,
+	REFRESH_MODULE_CHILDADDED,
+	REFRESH_MODULE_LAST
+};
+typedef boost::signal<void(IModule *, REFRESH_MODULE refreshType)> module_refresh_signal_type;
 typedef module_refresh_signal_type::slot_type module_refresh_slot_type;
 
 __interface IModule : public clib::ILockableUnknown
@@ -40,6 +46,7 @@ __interface IModule : public clib::ILockableUnknown
 	IRepository * GetRepository() const;
 
 	boost::signals::connection on_refresh_connect(const module_refresh_slot_type& s);
+	void Refresh(REFRESH_MODULE refreshType);  //  Triggers Refresh Notification Only  ---
 };
 
 class IModuleCompare

--- a/wlib/RepositoryTreeNode.cpp
+++ b/wlib/RepositoryTreeNode.cpp
@@ -1,7 +1,7 @@
 #include "StdAfx.h"
 #include "..\en_us\resource.h"
 
-#include ".\repositorytreenode.h"
+#include ".\RepositoryTreeNode.h"
 #include <util.h> //clib
 #include <utilDateTime.h> //clib
 #include <dali.h> //comms
@@ -90,7 +90,7 @@ void CRepositoryNode::LoadModules(IModuleVector & modules, CLoadingNode * loadin
 		{
 			CModuleNode * newNode = new CModuleNode(m_owner, itr->get());
 			newNode->InsertBelow(*GetTreeView(), m_bVirtualNode ? TVI_ROOT : *this);
-			newNode->operator ()(itr->get());
+			newNode->operator ()(itr->get(), REFRESH_MODULE_UNKNOWN);
 		}
 	}
 }
@@ -153,12 +153,21 @@ ATTRSTATE CModuleNode::GetState()
 	}
 	return ATTRSTATE_LOCKED;
 }
-void CModuleNode::operator()(IModule * /*module*/)
+void CModuleNode::operator()(IModule * /*module*/, REFRESH_MODULE refreshType)
 {
 	if (GetTreeView())
 	{
 		SetState(-1, TVIS_STATEIMAGEMASK);
 		SetState(INDEXTOSTATEIMAGEMASK(GetStateIcon(GetState())), TVIS_STATEIMAGEMASK);
+	}
+	switch (refreshType) {
+	case REFRESH_MODULE_CHILDADDED:
+		if (IsExpanded())
+		{
+			Expand(TVE_COLLAPSE | TVE_COLLAPSERESET);
+			Expand();
+		}
+		break;
 	}
 }
 
@@ -181,7 +190,7 @@ void CModuleNode::ItemExpanding()
 	{
 		CModuleNode * newNode = new CModuleNode(m_owner, itr->get());
 		newNode->InsertBelow(*GetTreeView(), *this);
-		newNode->operator ()(newNode->GetModule());
+		newNode->operator ()(newNode->GetModule(), REFRESH_MODULE_UNKNOWN);
 	}
 	for (IAttributeVector::iterator itr = attributes.begin(); itr != attributes.end(); ++itr)
 	{

--- a/wlib/RepositoryTreeNode.h
+++ b/wlib/RepositoryTreeNode.h
@@ -137,7 +137,7 @@ public:
 	int GetDispSelectedImage();
 	int GetDispChildren();
 	ATTRSTATE GetState();
-	void operator()(IModule *module);
+	void operator()(IModule *module, REFRESH_MODULE refreshType);
 
 	IModule * GetModule();
 	void SetNextExpandShouldBeFast();


### PR DESCRIPTION
Repository tree does not refresh correctly when a new file is added to one of
its folders.

Fixes IDE-394

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
