### PR TITLE
IDE-325 MOD File Import Issue

### DIFF
--- a/comms/Attribute.cpp
+++ b/comms/Attribute.cpp
@@ -490,7 +490,7 @@ public:
 
 	void Refresh(bool eclChanged, IAttribute * newAttrAsOldOneMoved, bool deleted)
 	{
-		if (deleted) 
+		if (deleted || newAttrAsOldOneMoved) 
 			DeleteAttribute(this);
 
 		on_refresh(this, eclChanged, newAttrAsOldOneMoved, deleted);


### PR DESCRIPTION
(Remote Repository Only)
Deleting an attribute and then importing a MOD file with a matching mod.attr
name, will fail.

Fixes IDE-325

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
