### PR TITLE
IDE-443: Limiting GridCtrl.cpp tooltip text size

### DIFF
--- a/sgrid/GridCtrl_src/TitleTip.cpp
+++ b/sgrid/GridCtrl_src/TitleTip.cpp
@@ -134,7 +134,9 @@ void CTitleTip::Show(CRect rectTitle, LPCTSTR lpszTitleText, int xoffset /*=0*/,
                      LPRECT lpHoverRect /*=NULL*/,
                      const LOGFONT* lpLogFont /*=NULL*/,
                      COLORREF crTextClr /* CLR_DEFAULT */,
-                     COLORREF crBackClr /* CLR_DEFAULT */)
+                     COLORREF crBackClr /* CLR_DEFAULT */,
+                     int nMaxChars /*=-1*/
+    )
 {
     if (!IsWindow(m_hWnd))
         Create(m_pParentWnd);
@@ -330,7 +332,9 @@ void CTitleTip::Show(CRect rectTitle, LPCTSTR lpszTitleText, int xoffset /*=0*/,
 
     rectCalc.top += 1;
 
-    int nHeight = dc.DrawText(m_strTitle,&rectCalc,0 
+    m_strTitle = LimitTooltip(m_strTitle, rectClient, tm, nMaxChars);
+
+    int nHeight = dc.DrawText(m_strTitle, &rectCalc, 0
         | DT_CALCRECT
         | DT_LEFT
         | DT_NOCLIP
@@ -378,6 +382,23 @@ void CTitleTip::Show(CRect rectTitle, LPCTSTR lpszTitleText, int xoffset /*=0*/,
     //dc.TextOut( 0, 0, m_strTitle );
     SetCapture();
     dc.SelectObject(pOldFont);
+}
+
+CString CTitleTip::LimitTooltip(const CString & tooltipStr, CRect rectDisplay, TEXTMETRIC tm, int nMaxChars)
+{
+    int len = tooltipStr.GetLength();
+
+    if (nMaxChars >= 0)
+        return len > nMaxChars ? tooltipStr.Mid(0, nMaxChars) : tooltipStr;
+
+    ATLASSERT(len <= 50000);
+
+    int rowCharCount = rectDisplay.Width() / tm.tmAveCharWidth;
+    int numRows = rectDisplay.Height() / tm.tmHeight;
+    // -3 for the added spaces in the display of the tooltip string which translate into lines
+    int maxCharCount = rowCharCount * (numRows - 3) + 1;
+
+    return len > maxCharCount ? tooltipStr.Mid(0, maxCharCount) : tooltipStr;
 }
 
 void CTitleTip::Hide()

--- a/sgrid/GridCtrl_src/TitleTip.h
+++ b/sgrid/GridCtrl_src/TitleTip.h
@@ -52,7 +52,7 @@ public:
     void Show(CRect rectTitle, LPCTSTR lpszTitleText, 
               int xoffset = 0, LPRECT lpHoverRect = NULL, 
               const LOGFONT* lpLogFont = NULL,
-              COLORREF crTextClr = CLR_DEFAULT, COLORREF crBackClr = CLR_DEFAULT);
+              COLORREF crTextClr = CLR_DEFAULT, COLORREF crBackClr = CLR_DEFAULT, int nMaxChars = -1);
     void Hide();
 
 // Overrides
@@ -77,6 +77,7 @@ protected:
 
 protected:
     void ProcessMouseMessage(MSG* pMsg); 
+    CString LimitTooltip(const CString & limitStr, CRect rectDisplay, TEXTMETRIC tm, int nMaxChars = -1);
 
     // Generated message map functions
 protected:


### PR DESCRIPTION
Fixes IDE-443

Signed-off-by: dehilsterlexis david.dehilster@lexisnexis.com
