### PR TITLE
IDE-437 File rename doesn't "stick"

### DIFF
--- a/eclide/EclDlgBuilder.cpp
+++ b/eclide/EclDlgBuilder.cpp
@@ -770,10 +770,10 @@ void CBuilderDlg::operator()(IAttribute * attr, bool eclChanged, IAttribute * ne
         else if (doSaveAs == IDNO)
             m_owner->Close();
     }
-    else 
+    else if (newAttrAsOldOneMoved)
     {
-        //TODO handle renamed.
-        //ATLASSERT(FALSE);
+        SetAttribute(newAttrAsOldOneMoved);
+        SetNamePath(newAttrAsOldOneMoved->GetPath());
     }
 }
 


### PR DESCRIPTION
Builder window switches to new attribute.
Update path.

Fixes IDE-437

Signed-off-by: Gordon Smith gordonjsmith@gmail.com
