### PR TITLE
IDE-502 Include vcredist_x86.exe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,18 +99,6 @@ ENDIF ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 ##############################################
 
 ####  CPACK  ####
-set ( CMAKE_INSTALL_MFC_LIBRARIES TRUE )
-set ( CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE )
-include ( InstallRequiredSystemLibraries )
-foreach ( CMAKE_INSTALL_SYSTEM_RUNTIME_LIB ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} )
-    ##  Skip non unicode version of MFC libs (big)  ##
-    string(REGEX MATCH ".*mfc.*0\\.dll" SKIP_FILE "${CMAKE_INSTALL_SYSTEM_RUNTIME_LIB}" )
-    if ( SKIP_FILE )
-        message("Skipping non unicode MFC install:  ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIB}")
-    else ( SKIP_FILE )
-        install ( PROGRAMS ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIB} DESTINATION bin )
-    endif ( SKIP_FILE)
-endforeach ( CMAKE_INSTALL_SYSTEM_RUNTIME_LIB )
 
 set ( CPACK_PACKAGE_VENDOR "HPCC Systems" )
 set ( CPACK_PACKAGE_NAME "hpccsystems-eclide" )


### PR DESCRIPTION
Switch from local runtimes to global install of runtimes.

Fixes IDE-502

Signed-off-by: Gordon Smith gordonjsmith@gmail.com
