### PR TITLE
IDE-513 Graph Timing List Sync Issue

### DIFF
--- a/eclide/GraphView2.h
+++ b/eclide/GraphView2.h
@@ -203,6 +203,11 @@ public:
         return boost::lexical_cast<int>(uid.GetID());
     }
 
+    int GetItem(int globalID)
+    {
+        return GetItem(boost::lexical_cast<std::_tstring>(globalID));
+    }
+
     int GetItem(const std::_tstring globalID)
     {
         CComVariant vaResult;
@@ -219,10 +224,10 @@ public:
         return vaResult;
     }
 
-    void CenterGraphItem(int item, bool scaleToFit = true)
+    void CenterGraphItem(int item, bool scaleToFit = true, bool widthOnly = false)
     {
         CComVariant vaResult;
-        bool retVal = InvokeScript(_T("centerOnItem"), boost::lexical_cast<std::_tstring>(item), boost::lexical_cast<std::_tstring>(scaleToFit), vaResult);
+        bool retVal = InvokeScript(_T("centerOnItem"), boost::lexical_cast<std::_tstring>(item), boost::lexical_cast<std::_tstring>(scaleToFit), boost::lexical_cast<std::_tstring>(widthOnly), vaResult);
         ATLASSERT(retVal);
     }
 

--- a/eclide/GraphView3.cpp
+++ b/eclide/GraphView3.cpp
@@ -288,7 +288,7 @@ void CGraphView3::CenterOnItem(const CUniqueID & id)
 
 void CGraphView3::CenterOnTiming(const Dali::CGraphTiming * timing)
 {
-    CUniqueID id(guidDefault, XGMML_CAT_SUBGRAPH, boost::lexical_cast<std::_tstring>(timing->m_gid));
+    CUniqueID id(guidDefault, XGMML_CAT_SUBGRAPH, boost::lexical_cast<std::_tstring>(m_wndLNGVC.GetItem(timing->m_gid)));
     CenterOnItem(id);
 }
 


### PR DESCRIPTION
Selecting a timing passes GlobalID instead of InternalID to the graph control.
Add optional param to scaleToFit.

Fixes IDE-513

Signed-off-by: Gordon Smith gordonjsmith@gmail.com
