### PR TITLE
IDE-538 Import large MOD files, fail

### DIFF
--- a/comms/Attribute.cpp
+++ b/comms/Attribute.cpp
@@ -214,6 +214,14 @@ public:
         return m_repository->Save(attrs, noBroadcast);
     }
 
+    void UnloadText()
+    {
+        clib::recursive_mutex::scoped_lock proc(m_mutex);
+        m_ecl.Empty();
+        m_ecl.FreeExtra();
+        m_eclSet = false;
+    }
+
     bool IsCheckedOut() const
     {
         clib::recursive_mutex::scoped_lock proc(m_mutex);

--- a/comms/Attribute.h
+++ b/comms/Attribute.h
@@ -79,6 +79,7 @@ __interface __declspec(uuid("1D743D5B-2719-4b7d-A5EB-4D5ACF34A493")) IAttribute 
     const TCHAR *GetChecksumLocalTidied() const;
     int GetVersion() const;
     bool SetText(const TCHAR* ecl, bool noBroadcast = false);
+    void UnloadText();
     bool IsCheckedOut() const;
     bool IsSandboxed() const;
     bool IsLocked() const;

--- a/comms/DiskAttribute.cpp
+++ b/comms/DiskAttribute.cpp
@@ -226,6 +226,14 @@ public:
         return result;
     }
 
+    void UnloadText()
+    {
+        clib::recursive_mutex::scoped_lock proc(m_mutex);
+        m_ecl.Empty();
+        m_ecl.FreeExtra();
+        m_eclSet = false;
+    }
+
     bool IsCheckedOut() const
     {
         clib::recursive_mutex::scoped_lock proc(m_mutex);

--- a/comms/Migration.cpp
+++ b/comms/Migration.cpp
@@ -10,6 +10,96 @@
 #define NUM_TRYS 10
 #define MAX_THREAD_COUNT 5
 
+class CMigrationItem : public CUnknown, public IMigrationItem
+{
+private:
+    std::_tstring m_modLabel;
+    std::_tstring m_attrLabel;
+    CComPtr<IAttributeType> m_attrType;
+    std::string m_comment;
+    std::string m_ecl;
+
+public:
+    CMigrationItem(const std::_tstring & modLabel, const std::_tstring & attrLabel, IAttributeType * attrType, const std::string & comment, const std::string & ecl)
+        : m_modLabel(modLabel), m_attrLabel(attrLabel), m_attrType(attrType), m_comment(comment), m_ecl(ecl)
+    {
+    }
+    CMigrationItem(const std::_tstring & modLabel, const std::_tstring & attrLabel, IAttributeType * attrType, const std::_tstring & comment, const std::_tstring & ecl)
+        : m_modLabel(modLabel), m_attrLabel(attrLabel), m_attrType(attrType)
+    {
+        m_comment = CT2A(comment.c_str(), CP_UTF8);
+        m_ecl = CT2A(ecl.c_str(), CP_UTF8);
+    }
+    CMigrationItem(const std::_tstring & modAttrLabel, IAttributeType * attrType, const std::string & comment, const std::string & ecl)
+        : m_attrType(attrType), m_comment(comment), m_ecl(ecl)
+    {
+        QualifiedLabel(modAttrLabel);
+    }
+    CMigrationItem(const std::_tstring & modAttrLabel, IAttributeType * attrType, const std::_tstring & comment, const std::_tstring & ecl)
+        : m_attrType(attrType)
+    {
+        QualifiedLabel(modAttrLabel);
+        m_comment = CT2A(comment.c_str(), CP_UTF8);
+        m_ecl = CT2A(ecl.c_str(), CP_UTF8);
+    }
+
+    BEGIN_CUNKNOWN
+    END_CUNKNOWN(CUnknown)
+
+    void QualifiedLabel(const std::_tstring & modAttrLabel)
+    {
+        typedef std::vector<std::_tstring> split_vector_type;
+        split_vector_type SplitVec;
+        boost::algorithm::split(SplitVec, modAttrLabel, boost::algorithm::is_any_of("."), boost::algorithm::token_compress_on);
+        for (split_vector_type::size_type i = 0; i < SplitVec.size(); ++i)
+        {
+            if (i == SplitVec.size() - 1)
+                m_attrLabel = SplitVec[i];
+            else
+            {
+                if (!m_modLabel.empty())
+                    m_modLabel += _T(".");
+                m_modLabel += SplitVec[i];
+            }
+        }
+    }
+    std::_tstring QualifiedLabel() const
+    {
+        std::_tstring retVal = m_modLabel;
+        if (!retVal.empty())
+            retVal += _T(".");
+        return retVal + m_attrLabel;
+    }
+    std::_tstring ModuleLabel() const
+    {
+        return m_modLabel;
+    }
+    std::_tstring AttributeLabel() const
+    {
+        return m_attrLabel;
+    }
+    IAttributeType * AttributeType() const
+    {
+        return m_attrType;
+    }
+    bool HasComment() const
+    {
+        return !m_comment.empty();
+    }
+    void Comment(const std::_tstring & comment)
+    {
+        m_comment = CT2A(comment.c_str(), CP_UTF8);
+    }
+    std::_tstring Comment() const
+    {
+        return std::_tstring(CA2T(m_comment.c_str(), CP_UTF8));
+    }
+    std::_tstring ECL() const
+    {
+        return std::_tstring(CA2T(m_ecl.c_str(), CP_UTF8));
+    }
+};
+
 class CMigrationCallbackStub : public IMigrationCallback
 {
     BOOL Invalidate(BOOL bErase = TRUE)
@@ -143,11 +233,7 @@ protected:
     struct thread_AddEclToModule_params 
     {
         IModuleAdapt module; 
-        std::_tstring moduleLabel; 
-        std::_tstring attrLabel; 
-        CComPtr<IAttributeType> type; 
-        std::_tstring comment; 
-        std::_tstring ecl; 
+        StlLinked<IMigrationItem> migrationItem; 
         std::_tstring modBy; 
         std::_tstring modWhen; 
         bool sandbox;
@@ -157,30 +243,33 @@ protected:
         }
     };
 
-    static void thread_AddEclToModule(CComPtr<CMigration> self, thread_AddEclToModule_params params, int retries, int maxThreadCount)
+    static void thread_AddEclToModule(CComPtr<CMigration> self, thread_AddEclToModule_params * params, int retries, int maxThreadCount)
     {
+        std::_tstring toModLabel = params->migrationItem->ModuleLabel();
+        std::_tstring toAttrLabel = params->migrationItem->AttributeLabel();
+        CComPtr<IAttributeType> toAttrType = params->migrationItem->AttributeType();
 #ifndef _DEBUG
         try
         {
 #endif
-            if (params.module)
-                params.moduleLabel = params.module->GetQualifiedLabel() + std::_tstring(_T(".")) + params.moduleLabel;
-            self->m_caller->LogMsg((boost::_tformat(_T("%1%.%2%:  Migration Start")) % params.moduleLabel % params.attrLabel).str());
-            IModuleAdapt toMod = GetModule(self->m_targetRep, params.moduleLabel.c_str(), retries);
+            if (params->module)
+                toModLabel = params->module->GetQualifiedLabel() + std::_tstring(_T(".")) + toModLabel;
+            self->m_caller->LogMsg((boost::_tformat(_T("%1%.%2%:  Migration Start")) % toModLabel % toAttrLabel).str());
+            IModuleAdapt toMod = GetModule(self->m_targetRep, toModLabel.c_str(), retries);
             if (!toMod)
-                toMod = GetModulePlaceholder(self->m_targetRep, params.moduleLabel.c_str(), retries);
+                toMod = GetModulePlaceholder(self->m_targetRep, toModLabel.c_str(), retries);
             if (!toMod)
             {
-                self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  AMT Unable To Locate \"toMod\"")) % params.moduleLabel % params.attrLabel).str());
+                self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  AMT Unable To Locate \"toMod\"")) % toModLabel % toAttrLabel).str());
                 ATLASSERT(false);
                 return;
             }
-            IAttributeAdapt toAttr = GetAttribute(self->m_targetRep, params.moduleLabel.c_str(), params.attrLabel.c_str(), params.type, retries);
+            IAttributeAdapt toAttr = GetAttribute(self->m_targetRep, toModLabel.c_str(), toAttrLabel.c_str(), toAttrType, retries);
             if (!toAttr)
-                toAttr = GetAttributePlaceholder(self->m_targetRep, params.moduleLabel.c_str(), params.attrLabel.c_str(), params.type, retries);
+                toAttr = GetAttributePlaceholder(self->m_targetRep, toModLabel.c_str(), toAttrLabel.c_str(), toAttrType, retries);
             if (!toAttr)
             {
-                self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  AMT Unable To Locate \"toAttr\"")) % params.moduleLabel % params.attrLabel).str());
+                self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  AMT Unable To Locate \"toAttr\"")) % toModLabel % toAttrLabel).str());
                 ATLASSERT(false);
                 return;
             }
@@ -190,49 +279,50 @@ protected:
             if (!toMod->Exists())
             {
                 if (!toMod->Create())
-                    self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  Create Folder Failed")) % params.moduleLabel % params.attrLabel).str());
+                    self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  Create Folder Failed")) % toModLabel % toAttrLabel).str());
             }
 
             if (!toAttr->Exists())
             {
                 if (!toAttr->Create())
-                    self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  Create File Failed")) % params.moduleLabel % params.attrLabel).str());
+                    self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  Create File Failed")) % toModLabel % toAttrLabel).str());
             }
 
             if (toAttr)
             {
                 if (toAttr->IsLocked())
-                    self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  Target File Locked")) % params.moduleLabel % params.attrLabel).str());
+                    self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  Target File Locked")) % toModLabel % toAttrLabel).str());
                 else 
                 {
                     bool result = true;
                     std::_tstring toEcl = GetText(toAttr->GetAsHistory(), retries);
-                    if (boost::algorithm::equals(params.ecl, toEcl) && boost::algorithm::equals(toAttr->GetChecksum(), toAttr->GetChecksumLocal()))
-                        self->m_caller->LogMsg((boost::_tformat(_T("%1%.%2%:  ECL already matches, skipping.")) % params.moduleLabel % params.attrLabel).str());
+                    if (boost::algorithm::equals(params->migrationItem->ECL(), toEcl) && boost::algorithm::equals(toAttr->GetChecksum(), toAttr->GetChecksumLocal()))
+                        self->m_caller->LogMsg((boost::_tformat(_T("%1%.%2%:  ECL already matches, skipping.")) % toModLabel % toAttrLabel).str());
                     else
                     {
-                        if (!params.sandbox && !toAttr->IsCheckedOut())
+                        if (!params->sandbox && !toAttr->IsCheckedOut())
                         {
                             result = Checkout(toAttr, retries);
                             if (!result)
-                                self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  Unable To Checkout Target File")) % params.moduleLabel % params.attrLabel).str());
+                                self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  Unable To Checkout Target File")) % toModLabel % toAttrLabel).str());
                         }
                         if (result)
                         {
-                            result = SetText(toAttr, params.ecl.c_str(), params.setTextNoBroadcast, retries);
+                            result = SetText(toAttr, params->migrationItem->ECL().c_str(), params->setTextNoBroadcast, retries);
                             if (!result)
-                                self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  Unable To Save Target ECL")) % params.moduleLabel % params.attrLabel).str());
+                                self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  Unable To Save Target ECL")) % toModLabel % toAttrLabel).str());
                         }
                     }
-                    if (!params.sandbox && toAttr->IsCheckedOut())
+                    if (!params->sandbox && toAttr->IsCheckedOut())
                     {
-                        result = Checkin(toAttr, params.comment.c_str(), retries);
+                        result = Checkin(toAttr, params->migrationItem->Comment().c_str(), retries);
                         if (!result)
-                            self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  Unable To Checkin Target File")) % params.moduleLabel % params.attrLabel).str());
+                            self->m_caller->LogMsg((boost::_tformat(_T("Failed (%1%.%2%):  Unable To Checkin Target File")) % toModLabel % toAttrLabel).str());
                     }
+                    toAttr->UnloadText();
                 }
             }
-            self->m_caller->LogMsg((boost::_tformat(_T("%1%.%2%:  Migration End")) % params.moduleLabel % params.attrLabel).str());
+            self->m_caller->LogMsg((boost::_tformat(_T("%1%.%2%:  Migration End")) % toModLabel % toAttrLabel).str());
             if (self->m_threads.Size() <= 1 || self->m_threads.Size() % maxThreadCount == 0)
             {
                 self->m_caller->Invalidate(false);
@@ -251,13 +341,14 @@ protected:
         }
         catch (std::exception & e)
         {
-            self->m_caller->LogMsg((boost::_tformat(_T("Exception(%1%.%2%):  %3%.")) % params.moduleLabel % params.attrLabel % e.what()).str());
+            self->m_caller->LogMsg((boost::_tformat(_T("Exception(%1%.%2%):  %3%.")) % toModLabel % toAttrLabel % e.what()).str());
         }
         catch (...)
         {
-            self->m_caller->LogMsg((boost::_tformat(_T("Exception(%1%.%2%):  Unknown.")) % params.moduleLabel % params.attrLabel).str());
+            self->m_caller->LogMsg((boost::_tformat(_T("Exception(%1%.%2%):  Unknown.")) % toModLabel % toAttrLabel).str());
         }
 #endif
+        delete params;
     }
 
     static void thread_AddWsToRep(CComPtr<CMigration> self, IWorkspaceAdapt fromWorkspace, int retries, int maxThreadCount)
@@ -309,17 +400,13 @@ protected:
 
     static void thread_AddToRep(CComPtr<CMigration> self, IModuleAdapt targetModule, IAttributeHistoryAdapt fromAttr, const std::_tstring comment, bool sandbox, bool setTextNoBroadcast, int retries, int maxThreadCount)
     {
-        thread_AddEclToModule_params params;
-        params.module = targetModule;
-        params.moduleLabel = fromAttr->GetModuleQualifiedLabel(true);
-        params.attrLabel = fromAttr->GetLabel();
-        params.type = fromAttr->GetType(); 
-        params.comment = comment; 
-        params.ecl = GetText(fromAttr, retries); 
-        params.modBy = fromAttr->GetModifiedBy(); 
-        params.modWhen = fromAttr->GetModifiedDate(); 
-        params.sandbox = sandbox;
-        params.setTextNoBroadcast = setTextNoBroadcast;
+        thread_AddEclToModule_params * params = new thread_AddEclToModule_params();
+        params->module = targetModule;
+        params->migrationItem = new CMigrationItem(fromAttr->GetModuleQualifiedLabel(true), fromAttr->GetLabel(), fromAttr->GetType(), comment, GetText(fromAttr, retries)); 
+        params->modBy = fromAttr->GetModifiedBy(); 
+        params->modWhen = fromAttr->GetModifiedDate(); 
+        params->sandbox = sandbox;
+        params->setTextNoBroadcast = setTextNoBroadcast;
         thread_AddEclToModule(self, params, retries, maxThreadCount);
     }
 
@@ -366,46 +453,32 @@ public:
         AddEclToModule(NULL, modAttrLabel, type, comment, ecl, by, sandbox);
     }
 
-    void AddEclToModule(IModuleAdapt module, const std::_tstring & modLabel, const std::_tstring & attrLabel, IAttributeType * type, const std::_tstring & comment, const std::_tstring & ecl, const std::_tstring & by, bool sandbox)
+    void AddEclToModule(IModuleAdapt module, StlLinked<IMigrationItem> migrationItem, const std::_tstring & by, bool sandbox)
     {
         std::_tstring modDate;
         CurrentDateTimeUTCString(modDate);
-        std::_tstring comments = comment.length() ? comment : (boost::_tformat(_T("%1%, Copied with AMT from File Modified by %2%")) % modDate % by).str();
+        if (!migrationItem->HasComment()) {
+            migrationItem->Comment((boost::_tformat(_T("%1%, Copied with AMT from File Modified by %2%")) % modDate % by).str());
+        }
 
-        thread_AddEclToModule_params params;
-        params.module = module;
-        params.moduleLabel = modLabel;
-        params.attrLabel = attrLabel;
-        params.type = type; 
-        params.comment = comments; 
-        params.ecl = ecl; 
-        params.modBy = by; 
-        params.modWhen = modDate; 
-        params.sandbox = sandbox;
-        params.setTextNoBroadcast = m_setTextNoBroadcast;
+        thread_AddEclToModule_params * params = new thread_AddEclToModule_params();
+        params->module = module;
+        params->migrationItem = migrationItem;
+        params->modBy = by;
+        params->modWhen = modDate;
+        params->sandbox = sandbox;
+        params->setTextNoBroadcast = m_setTextNoBroadcast;
         m_threads.Append(__FUNCTION__, boost::bind(&thread_AddEclToModule, this, params, m_retries, m_maxThreadCount));
+    }
+
+    void AddEclToModule(IModuleAdapt module, const std::_tstring & modLabel, const std::_tstring & attrLabel, IAttributeType * type, const std::_tstring & comment, const std::_tstring & ecl, const std::_tstring & by, bool sandbox)
+    {
+        AddEclToModule(module, new CMigrationItem(modLabel, attrLabel, type, comment, ecl), by, sandbox);
     }
 
     void AddEclToModule(IModuleAdapt module, const std::_tstring & modAttrLabel, IAttributeType * type, const std::_tstring & comment, const std::_tstring & ecl, const std::_tstring & by, bool sandbox)
     {
-        typedef std::vector<std::_tstring> split_vector_type;
-        split_vector_type SplitVec; 
-        boost::algorithm::split(SplitVec, modAttrLabel, boost::algorithm::is_any_of("."), boost::algorithm::token_compress_on);
-        std::_tstring modLabel, attrLabel;
-        for (split_vector_type::size_type i = 0; i < SplitVec.size(); ++i)
-        {
-            if (i == SplitVec.size() - 1)
-                attrLabel = SplitVec[i];
-            else 
-            {
-                if (!modLabel.empty())
-                    modLabel += _T(".");
-                modLabel += SplitVec[i];
-            }
-        }
-
-        if (!modLabel.empty() && !attrLabel.empty())
-            AddEclToModule(module, modLabel, attrLabel, type, comment, ecl, by, sandbox);
+        AddEclToModule(module, new CMigrationItem(modAttrLabel, type, comment, ecl), by, sandbox);
     }
 
     void Start()
@@ -451,4 +524,8 @@ IMigration * CreateIMigration(IRepository * targetRep, bool setTextNoBroadcast, 
     return new CMigration(caller, setTextNoBroadcast, targetRep);
 }
 
+IMigrationItem * CreateIMigrationItem(const std::_tstring & modAttrLabel, IAttributeType * attrType, const std::string & comment, const std::string & ecl)
+{
+    return new CMigrationItem(modAttrLabel, attrType, comment, ecl);
+}
 

--- a/comms/Migration.h
+++ b/comms/Migration.h
@@ -5,6 +5,20 @@
 #include "Workspace.h"
 #include "Thread.h"
 
+__interface IMigrationItem : public IUnknown
+{
+    void QualifiedLabel(const std::_tstring & modAttrLabel);
+    std::_tstring QualifiedLabel() const;
+    std::_tstring ModuleLabel() const;
+    std::_tstring AttributeLabel() const;
+    IAttributeType * AttributeType() const;
+
+    bool HasComment() const;
+    void Comment(const std::_tstring & comment);
+    std::_tstring Comment() const;
+    std::_tstring ECL() const;
+};
+
 __interface IMigrationCallback
 {
     BOOL Invalidate(BOOL bErase = TRUE);
@@ -19,6 +33,7 @@ __interface IMigration : public IUnknown
     void AddToRep(IModuleAdapt targetModule, IAttributeHistoryAdapt fromAttr, const std::_tstring & comment, bool sandbox);
     void AddEclToRep(const std::_tstring & modLabel, const std::_tstring & attrLabel, IAttributeType * type, const std::_tstring & comment, const std::_tstring & ecl, const std::_tstring & by, bool sandbox);
     void AddEclToRep(const std::_tstring & modAttrLabel, IAttributeType * type, const std::_tstring & comment, const std::_tstring & ecl, const std::_tstring & by, bool sandbox);
+    void AddEclToModule(IModuleAdapt module, StlLinked<IMigrationItem> migrationItem, const std::_tstring & by, bool sandbox);
     void AddEclToModule(IModuleAdapt module, const std::_tstring & modLabel, const std::_tstring & attrLabel, IAttributeType * type, const std::_tstring & comment, const std::_tstring & ecl, const std::_tstring & by, bool sandbox);
     void AddEclToModule(IModuleAdapt module, const std::_tstring & modAttrLabel, IAttributeType * type, const std::_tstring & comment, const std::_tstring & ecl, const std::_tstring & by, bool sandbox);
     void Start();
@@ -37,3 +52,4 @@ __interface IMigration : public IUnknown
 //		::Sleep(1000);
 
 COMMS_API IMigration * CreateIMigration(IRepository * targetRep, bool setTextNoBroadcast, IMigrationCallback * caller = NULL);
+COMMS_API IMigrationItem * CreateIMigrationItem(const std::_tstring & modAttrLabel, IAttributeType * attrType, const std::string & comment, const std::string & ecl);

--- a/comms/ModFileAttribute.cpp
+++ b/comms/ModFileAttribute.cpp
@@ -208,6 +208,14 @@ public:
         return m_repository->Save(attrs, noBroadcast);
     }
 
+    void UnloadText()
+    {
+        clib::recursive_mutex::scoped_lock proc(m_mutex);
+        m_ecl.Empty();
+        m_ecl.FreeExtra();
+        m_eclSet = false;
+    }
+
     bool IsCheckedOut() const
     {
         clib::recursive_mutex::scoped_lock proc(m_mutex);


### PR DESCRIPTION
* Adding support for files in the 300->600MB range.
* Keep ECL in "narrow" strings for as long as possible.
* Judicious clearing of memory structes as the core content is passed around.
* Eliminate string copies where possible.
* Stream from file.

Fixes IDE-538

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>