### PR TITLE
IDE-571 Wrong path for LexSALT.cxx in CMakeLists

### DIFF
--- a/EclEditor/CMakeLists.txt
+++ b/EclEditor/CMakeLists.txt
@@ -7,7 +7,7 @@ set ( SRCS
 
 		${SCINTILLA_INCLUDE_DIR}/include/SciLExer.h
 
-		${SCINTILLA_INCLUDE_DIR}/lexers/LexSALT.cxx
+		${ECLEDITOR_SOURCE_DIR}/LexSALT.cxx
 		${SCINTILLA_INCLUDE_DIR}/lexers/LexESDL.cxx
 
 		${SCINTILLA_INCLUDE_DIR}/Src/AutoComplete.cxx


### PR DESCRIPTION
Fixes IDE-571

Signed-off-by: dehilsterlexis <david.dehilster@lexisnexis.com>