### PR TITLE
IDE-571 Wrong path for LexSALT.cxx in CMakeLists

### DIFF
--- a/EclEditor/CMakeLists.txt
+++ b/EclEditor/CMakeLists.txt
@@ -7,8 +7,8 @@ set ( SRCS
 
 		${SCINTILLA_INCLUDE_DIR}/include/SciLExer.h
 
-		${SCINTILLA_INCLUDE_DIR}/lexers/LexSALT.cxx
-		${SCINTILLA_INCLUDE_DIR}/lexers/LexESDL.cxx
+		${ECLEDITOR_SOURCE_DIR}/LexSALT.cxx
+		${ECLEDITOR_SOURCE_DIR}/LexESDL.cxx
 
 		${SCINTILLA_INCLUDE_DIR}/Src/AutoComplete.cxx
 		${SCINTILLA_INCLUDE_DIR}/Src/AutoComplete.h


### PR DESCRIPTION
Fixes IDE-571

Signed-off-by: dehilsterlexis <david.dehilster@lexisnexis.com>