### PR TITLE
IDE-621 IDE Failing to build

### DIFF
--- a/EclEditor/CMakeLists.txt
+++ b/EclEditor/CMakeLists.txt
@@ -8,7 +8,7 @@ set ( SRCS
 		${SCINTILLA_INCLUDE_DIR}/include/SciLExer.h
 
 		${ECLEDITOR_SOURCE_DIR}/LexSALT.cxx
-		${SCINTILLA_INCLUDE_DIR}/lexers/LexESDL.cxx
+		${ECLEDITOR_SOURCE_DIR}/LexESDL.cxx
 
 		${SCINTILLA_INCLUDE_DIR}/Src/AutoComplete.cxx
 		${SCINTILLA_INCLUDE_DIR}/Src/AutoComplete.h


### PR DESCRIPTION
Wrong path in CMakeLists.txt

Fixes IDE-621

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>