### PR TITLE
IDE-436 Erroneous warning "Plugin not found - ecl.bat"

### DIFF
--- a/comms/AttributeImpl.h
+++ b/comms/AttributeImpl.h
@@ -48,7 +48,9 @@ public:
                 }
             }
         }
-        _DBGLOG(LEVEL_WARNING, (boost::format("Plugin not found - %1%") % batchFile).str().c_str());
+        if (!boost::algorithm::iequals(batchFile, "ecl.bat")) {
+            _DBGLOG(LEVEL_WARNING, (boost::format("Plugin not found - %1%") % batchFile).str().c_str());
+        }
         return false;
     }
 


### PR DESCRIPTION
Hide message (safer and may be useful having a ecl.bat hook later).

Fixes IDE-436

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>