### PR TITLE
IDE-629 Workspace serialization + Unicode ECL

### DIFF
--- a/clib/PersistMap.cpp
+++ b/clib/PersistMap.cpp
@@ -62,8 +62,6 @@ bool CPersistMap::serialize(std::_tstring & resultXml) const
         CComBSTR first = itr->first.c_str();
         CComBSTR second = itr->second.c_str();
         pContentHandler->startElement(empty, empty.Length(), empty, empty.Length(), first, first.Length(), pSAXAttrs);
-        CString content(second, second.Length());
-        CComBSTR utf8content = CA2W(CT2A(content, CP_UTF8));
         pContentHandler->characters(second, second.Length());
         pContentHandler->endElement(empty, empty.Length(),	empty, empty.Length(), first, first.Length());
     }

--- a/comms/Workspace.cpp
+++ b/comms/Workspace.cpp
@@ -11,7 +11,7 @@
 
 const TCHAR * const DEFAULT_LABEL = _T("Default");
 
-IWorkspaceItem * CreateIWorkspaceItem(IRepository * repository, const std::_tstring & data);
+IWorkspaceItem * CreateIWorkspaceItem(IRepository * repository, const std::string & data);
 //  ===========================================================================
 class CWorkspaceItemCompare
 {
@@ -109,7 +109,7 @@ void restore(T &s, const char * filename)
 }
 //  ===========================================================================
 typedef std::vector<std::_tstring> WorkspaceVector;
-typedef std::vector<std::_tstring> WindowsVector;
+typedef std::vector<std::string> WindowsVector;
 //  ===========================================================================
 class CWorkspace : public IWorkspace, public clib::CLockableUnknown
 {
@@ -258,7 +258,7 @@ public:
         m_windows.clear();
         for(IWorkspaceItemVector::const_iterator itr = windows.begin(); itr != windows.end(); ++itr)
         {
-            std::_tstring data;
+            std::string data;
             m_windows.push_back(itr->get()->Serialize(data));
         }
         Save();
@@ -271,14 +271,14 @@ public:
         {
             std::_tstring data;
             if (itr->get()->serialize(data))
-                m_windows.push_back(data);
+                m_windows.push_back(static_cast<const char *>(CT2A(data.c_str(), CP_UTF8)));
         }
         Save();
     }
     void AddWindow(const IWorkspaceItem & window)
     {
         clib::recursive_mutex::scoped_lock proc(m_mutex);
-        std::_tstring data;
+        std::string data;
         m_windows.push_back(window.Serialize(data));
         Save();
     }

--- a/comms/WorkspaceItem.cpp
+++ b/comms/WorkspaceItem.cpp
@@ -95,11 +95,11 @@ public:
         m_loaded = LOADING_UNKNOWN;
     }
 
-    CWorkspaceItem(IRepository * repository, const std::_tstring & data)
+    CWorkspaceItem(IRepository * repository, const std::string & data)
     {
         clib::recursive_mutex::scoped_lock proc(m_mutex);
         m_repository = repository;
-        m_props.deserializeXML(data.c_str());
+        m_props.deserializeXML(static_cast<const TCHAR *>(CA2T(data.c_str(), CP_UTF8)));
         m_id = m_props.Get(PERSIST_FILEPATH);
         UpdateID();
         m_attributeLoaded = false;
@@ -252,12 +252,12 @@ public:
         clib::recursive_mutex::scoped_lock proc(m_mutex);
         return m_label.c_str();
     }
-    const TCHAR * Serialize(std::_tstring & result) const
+    const char * Serialize(std::string & result) const
     {
         clib::recursive_mutex::scoped_lock proc(m_mutex);
         std::_tstring data;
         m_props.serialize(data);
-        result = data;
+        result = CT2A(data.c_str(), CP_UTF8);
         return result.c_str();
     }
     WORKSPACE_ITEM_TYPE GetType() const
@@ -442,7 +442,7 @@ typedef std::vector<HWND> CChildFrameVector;
 //  ===========================================================================
 static CacheT<std::_tstring, CWorkspaceItem> CWorkspaceItemCache;
 
-IWorkspaceItem * CreateIWorkspaceItem(IRepository * repository, const std::_tstring & data)
+IWorkspaceItem * CreateIWorkspaceItem(IRepository * repository, const std::string & data)
 {
     StlLinked<CWorkspaceItem> workspaceItem = CWorkspaceItemCache.Get(new CWorkspaceItem(repository, data));
     workspaceItem->Load();

--- a/comms/WorkspaceItem.h
+++ b/comms/WorkspaceItem.h
@@ -16,7 +16,7 @@ enum WORKSPACE_ITEM_TYPE
 
 __interface __declspec(uuid("A4A4FFF2-0DED-422F-B06B-B0FE4CDB6C52")) IWorkspaceItem : public IUnknown
 {
-    const TCHAR * Serialize(std::_tstring & result) const;
+    const char * Serialize(std::string & result) const;
     IRepository * GetRepository() const;
     const TCHAR * GetID() const;
     const TCHAR * GetLabel() const;


### PR DESCRIPTION
Serialization fails when ECL contains Unicode characters.
Force workspace items to char* + UTF8 for serialization

Fixes IDE-629

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>