### PR TITLE
IDE-634 Add double quotes to Username and Workunit when passing to batch files

### DIFF
--- a/comms/AttributeImpl.h
+++ b/comms/AttributeImpl.h
@@ -133,7 +133,7 @@ public:
             errorFile.Create(NULL, GENERIC_READ);
             errorFile.HandsOff();
             
-            std::_tstring cmd = (boost::_tformat(_T("cmd /c %1% %2% %3% %4% %5% %6% %7% %8% \"%9%\" %10% \"%11%\"")) % 
+            std::_tstring cmd = (boost::_tformat(_T("cmd /c %1% %2% %3% %4% %5% %6% %7% \"%8%\" \"%9%\" \"%10%\" \"%11%\"")) % 
                 batchFile.c_str() %
                 PREPROCESS_LABEL[action] %
                 GetModuleQualifiedLabel(true) % 
@@ -144,7 +144,7 @@ public:
                 static_cast<const TCHAR *>(CString(GetIConfig(QUERYBUILDER_CFG)->Get(GLOBAL_USER))) % 
                 eclFolders % 
                 static_cast<const TCHAR *>(CString(GetIConfig(QUERYBUILDER_CFG)->Get(GLOBAL_SERVER_WORKUNIT))) %
-            static_cast<const TCHAR *>(CString(GetIConfig(QUERYBUILDER_CFG)->Get(GLOBAL_PASSWORD)))).str();
+                static_cast<const TCHAR *>(CString(GetIConfig(QUERYBUILDER_CFG)->Get(GLOBAL_PASSWORD)))).str();
 
             //_DBGLOG(m_url, LEVEL_INFO, cmd.c_str());
             std::_tstring in;


### PR DESCRIPTION
Fixed IDE-634

Signed-off-by: dehilsterlexis <david.dehilster@lexisnexis.com>