### PR TITLE
IDE-658 Set real version for start menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,19 @@ ADD_SUBDIRECTORY ( eclide )
 ADD_SUBDIRECTORY ( amt )
 set ( DOC_FILES 
     ${PROJECT_SOURCE_DIR}/docs/ECLReference.chm
+    ${PROJECT_SOURCE_DIR}/docs/LangColorDUD.xml
+    ${PROJECT_SOURCE_DIR}/docs/LangColorECL.xml
+    ${PROJECT_SOURCE_DIR}/docs/LangColorESDL.xml
+    ${PROJECT_SOURCE_DIR}/docs/LangColorKEL.xml
+    ${PROJECT_SOURCE_DIR}/docs/LangColorSalt.xml
     ${PROJECT_SOURCE_DIR}/docs/LanguageColor.xml
     ${PROJECT_SOURCE_DIR}/docs/LanguageReference.xml
+    ${PROJECT_SOURCE_DIR}/docs/LanguageRefDUD.xml
+    ${PROJECT_SOURCE_DIR}/docs/LanguageRefECL.xml
+    ${PROJECT_SOURCE_DIR}/docs/LanguageRefESDL.xml
+    ${PROJECT_SOURCE_DIR}/docs/LanguageRefKEL.xml
+    ${PROJECT_SOURCE_DIR}/docs/LanguageRefSalt.xml
+    ${PROJECT_SOURCE_DIR}/docs/SyntaxColorSamples.xml
   )
 install ( FILES ${DOC_FILES} DESTINATION bin )
 Install ( FILES ${PROJECT_SOURCE_DIR}/LICENSE.txt DESTINATION "." )
@@ -163,7 +174,7 @@ if ( WIN32 )
     set ( version ${HPCC_MAJOR}.${HPCC_MINOR}.${HPCC_POINT} )
     set ( CPACK_PACKAGE_INSTALL_DIRECTORY "${DIR_NAME}\\\\${version}\\\\eclide" )
     ####  Change the following if you _don't_ want the installer to uninstall previous versions ####
-    set ( CPACK_PACKAGE_INSTALL_REGISTRY_KEY "eclide_${HPCC_MAJOR}.0.0" )
+    set ( CPACK_PACKAGE_INSTALL_REGISTRY_KEY "eclide_${HPCC_MAJOR}" )
     set ( CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL "ON" )
     set ( CPACK_NSIS_URL_INFO_ABOUT "http:\\\\\\\\hpccsystems.com" )
     set ( CPACK_NSIS_INSTALLED_ICON_NAME "bin\\\\eclide.exe" )


### PR DESCRIPTION
This can be verified during ECLIDE installation.
Also there are additional docs/*.xml files for ECL code coloring. These file are installed to bin directory. Previous LanguageColor.xml and LanguageReference.xml may not be required anymore. But I am not sure so I still include them.

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com> 

@dehilsterlexis please review the change.
@JamesDeFabia  Please help testing. The private build: http://10.240.32.242/builds/custom/JIRA/IDE-658/hpccsystems-eclide-community_6.4.0-rc1Windows-i386.exe