### PR TITLE
IDE-703 Editor ignores tab width

### DIFF
--- a/wlib/SourceView.cpp
+++ b/wlib/SourceView.cpp
@@ -391,7 +391,7 @@ void CSourceCtrl::DoInit()
 {
     InitLanguage();
 
-    SetTabWidth((int)GetIConfig(QUERYBUILDER_CFG)->Get(GLOBAL_TAB_WIDTH));
+    SetTabWidth((int)GetIConfig(QUERYBUILDER_CFG)->Get(GLOBAL_TAB_WIDTH) * 2);
     SetUseTabs(!(bool)GetIConfig(QUERYBUILDER_CFG)->Get(GLOBAL_TAB_USESPACES));
 
     if (GetIConfig(QUERYBUILDER_CFG)->Get(GLOBAL_LINENO))


### PR DESCRIPTION
In my IDE tab width is set to be 2 spaces. This works fine for any new code, but if I open an attribute with existing tabs, the tabs in it have width equal to a single space.