### PR TITLE
IDE-696 Change hot keys for CMD Process logging

### DIFF
--- a/clib/cmdProcess.cpp
+++ b/clib/cmdProcess.cpp
@@ -296,7 +296,7 @@ public:
 
 int CLIB_API runProcess(const std::_tstring &command, const std::_tstring &directory, const std::_tstring &_path, const std::_tstring &in, std::_tstring &out, std::_tstring &err)
 {
-        if 	((GetKeyState(VK_SHIFT) & 0x8000) != 0)
+        if 	((GetKeyState(VK_SHIFT) & 0x8000) != 0 && (GetKeyState(VK_CONTROL) & 0x8000) != 0 && (GetKeyState(VK_MENU) & 0x8000) != 0)
         {
             std::_tstring clippy = _T("\r\ncd ");
             clippy += directory + _T("\r\n");


### PR DESCRIPTION
Added extra modifiers to make it harder for accidental triggering.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>