### PR TITLE
IDE-625 Extraneous message on Syntax Check

### DIFF
--- a/eclide/EclDlgBuilder.cpp
+++ b/eclide/EclDlgBuilder.cpp
@@ -81,7 +81,10 @@ bool CBuilderDlg::DoSave(bool attrOnly)
         IAttributeBookkeep attrProcessed;
         MetaInfo metaInfo;
         m_attribute->PreProcess(PREPROCESS_SAVE, NULL, attrs, attrProcessed, errors, metaInfo);
-        SendMessage(CWM_SUBMITDONE, Dali::WUActionCheck, (LPARAM)&errors);
+        if (!m_attribute->GetType()->IsTypeOf(ATTRIBUTE_TYPE_ECL) || m_attribute->GetType()->IsTypeOf(ATTRIBUTE_TYPE_ECL) && !errors.empty())
+        {
+            SendMessage(CWM_SUBMITDONE, Dali::WUActionCheck, (LPARAM)&errors);
+        }
         if (attrs.size())
         {
             if (!m_migrator)


### PR DESCRIPTION
@GordonSmith I used spy++ to see if there were any changes in window pointers but never found them to be different. I used a logical check instead which I have tested with multiple checks on multiple windows at the same time.