### PR TITLE
IDE-734 Possible crash reading version information

### DIFF
--- a/EclLib/DefinitionParser.cpp
+++ b/EclLib/DefinitionParser.cpp
@@ -120,7 +120,7 @@ bool DefinitionToLocation(const std::_tstring & def_string, ParsedDefinition & r
         result = result1;
         return true;
     }
-#ifdef _DEBUG
+#ifdef _DEBUG_GRAMMAR
     else
     {
         std::_tstring parsed(def_string.begin(), parse_result.stop);
@@ -129,7 +129,7 @@ bool DefinitionToLocation(const std::_tstring & def_string, ParsedDefinition & r
     return false;
 }
 
-#ifdef _DEBUG
+#ifdef _DEBUG_GRAMMAR
 class _DefinitionToLocationTest 
 { 
 public:

--- a/EclLib/EclLib.cpp
+++ b/EclLib/EclLib.cpp
@@ -19,7 +19,7 @@ BOOL APIENTRY DllMain( HANDLE  /*hModule*/,
     return TRUE;
 }
 
-#ifdef _DEBUG
+#ifdef _DEBUG_GRAMMAR
 #include "EclErrorParser.h"
 class CTest {
 public:

--- a/EclLib/EclParser.cpp
+++ b/EclLib/EclParser.cpp
@@ -5372,7 +5372,7 @@ public:
         }
         catch(CAtlException)
         {
-#ifdef _DEBUG
+#ifdef _DEBUG_GRAMMAR
             {
                 CUnicodeFile file;
                 file.Create(_T("c:\\temp\\tmp.xml"));

--- a/EclLib/VersionParser.cpp
+++ b/EclLib/VersionParser.cpp
@@ -6,14 +6,14 @@ using namespace BOOST_SPIRIT_CLASSIC_NS;
 
 std::ostream& operator<< (std::ostream& os, const ParsedVersion& def)
 {
-    std::string preffix = CT2A(def.preffix.c_str(), CP_UTF8);
+    std::string prefix = CT2A(def.prefix.c_str(), CP_UTF8);
     std::string minorVersionAlpha = CT2A(def.minorVersionAlpha.c_str(), CP_UTF8);
     std::string suffixStr = CT2A(def.suffixStr.c_str(), CP_UTF8);
     std::string github = CT2A(def.github.c_str(), CP_UTF8);
     std::string buildAlpha = CT2A(def.buildAlpha.c_str(), CP_UTF8);
     os << "Version =\n"
         << "    {\n"
-        << "    preffix = " << preffix << "\n"
+        << "    prefix = " << prefix << "\n"
         << "    major version = " << def.majorVersion << "\n"
         << "    minor version = " << def.minorVersion << "\n"
         << "    minor version alpha = " << minorVersionAlpha << "\n"
@@ -58,8 +58,8 @@ struct version_parser : public boost::spirit::classic::grammar<version_parser, v
                               ), 
                 def_ide_str = majorVersion_num >> '.' >> minorVersion_num >> '.' >> pointVersion_num >> '.' >> build_num,
                 def_eclcc_str = def_ecllang_str >> def_oss_str,
-                def_oss_str = preffix_str >> delim >> majorVersion_num >> delim >> minorVersion_num >> delim >> pointVersion_num >> delim >> suffix_str >> !github_str,
-                def_build_str = preffix_str >> '_' >> majorVersion_num >> !('_' >> minorVersion_num >> !('_' >> pointVersion_num)),
+                def_oss_str = prefix_str >> delim >> majorVersion_num >> delim >> minorVersion_num >> delim >> pointVersion_num >> delim >> suffix_str >> !github_str,
+                def_build_str = prefix_str >> '_' >> majorVersion_num >> !('_' >> minorVersion_num >> !('_' >> pointVersion_num)),
 
                 delim =				ch_p('_') | '-' | '.',
 
@@ -67,7 +67,7 @@ struct version_parser : public boost::spirit::classic::grammar<version_parser, v
                                     >> '.' >> uint_p	[ASSIGN(lang_MinorVersion, arg1)]
                                     >> '.' >> uint_p	[ASSIGN(lang_PointVersion, arg1)],
 
-                preffix_str	=		(+alnum_p)			[ASSIGNSTR(preffix, arg1, arg2)],
+                prefix_str	=		(+alnum_p)			[ASSIGNSTR(prefix, arg1, arg2)],
                 majorVersion_num =	uint_p				[ASSIGN(majorVersion, arg1)],
                 minorVersion_num =	uint_p				[ASSIGN(minorVersion, arg1)]		>> !(alpha_p)	[ASSIGN(minorVersionAlpha, arg1)],
                 pointVersion_num =	uint_p				[ASSIGN(pointVersion, arg1)],
@@ -87,7 +87,7 @@ struct version_parser : public boost::spirit::classic::grammar<version_parser, v
         boost::spirit::classic::subrule<3> def_build_str;
         boost::spirit::classic::subrule<4> def_eclcc_str;
         boost::spirit::classic::subrule<5> def_ecllang_str;
-        boost::spirit::classic::subrule<6> preffix_str;
+        boost::spirit::classic::subrule<6> prefix_str;
         boost::spirit::classic::subrule<7> majorVersion_num;
         boost::spirit::classic::subrule<8> minorVersion_num;
         boost::spirit::classic::subrule<9> pointVersion_num;
@@ -119,7 +119,7 @@ bool ParseVersion(const std::_tstring & version_string, ParsedVersion & result)
         result = result1;
         return true;
     }
-#ifdef _DEBUG
+#ifdef _DEBUG_GRAMMAR
     else
     {
         std::_tstring parsed(trim_version_string.cbegin(), parse_result.stop);

--- a/EclLib/VersionParser.h
+++ b/EclLib/VersionParser.h
@@ -13,7 +13,7 @@ struct ParsedVersion
          BUILD,
          LAST
     } type;
-    std::_tstring preffix;
+    std::_tstring prefix;
     unsigned int majorVersion;
     unsigned int minorVersion;
     std::_tstring minorVersionAlpha;

--- a/EclLib/ecl_grammar.cpp
+++ b/EclLib/ecl_grammar.cpp
@@ -4,7 +4,7 @@
 void DoParse(const std::string & ecl, tree_parse_info<> &info)
 {
     ecl_grammar g;
-#ifdef _DEBUG
+#ifdef _DEBUG_GRAMMAR
     BOOST_SPIRIT_DEBUG_NODE(g);
 #endif
     info = pt_parse(ecl.c_str(), g, space_p);

--- a/EclLib/stdafx.h
+++ b/EclLib/stdafx.h
@@ -47,7 +47,7 @@ namespace std
 #define BOOST_SPIRIT_THREADSAFE 
 #define PHOENIX_THREADSAFE
 #define BOOST_LIB_DIAGNOSTIC
-#ifdef _DEBUG
+#ifdef _DEBUG_GRAMMAR
 #define BOOST_SPIRIT_DEBUG  
 #define BOOST_SPIRIT_DEBUG_OUT std::cerr
 #endif

--- a/comms/Account.cpp
+++ b/comms/Account.cpp
@@ -60,7 +60,8 @@ COMMS_API bool VerifyUser(IConfig * config, const CString &user, const CString &
     _ns1__VerifyUserRequest request;
     CStringAssign application(request.application, global::GetApplicationName());
     CComPtr<SMC::IVersion> version = GetCommsVersion();
-    CStringAssign versionStr(request.version, version->GetString());
+    std::_tstring versionStr2;
+    CStringAssign versionStr(request.version, version->GetString(versionStr2));
 
     _ns1__VerifyUserResponse response;
     ESP_EXCEPTION_LOG3(response.Exceptions);

--- a/comms/EclCC.cpp
+++ b/comms/EclCC.cpp
@@ -674,6 +674,7 @@ unsigned int FindAllCEclCC(CEclCCVector & results)
     return results.size();
 }
 
+const TCHAR * const warningTpl = _T("Compiler/Server mismatch:\r\nCompiler:\t%1%\r\nServer:\t%2%");
 IEclCC * CreateIEclCC()
 {
     if (g_EnableCompiler != TRI_BOOL_TRUE)
@@ -714,16 +715,18 @@ IEclCC * CreateIEclCC()
             if (bestMatchEclCC_before && versionCompare.distance(serverVersion, bestMatchEclCC_before->GetBuild()) < SMC::IVersionCompare::DISTANCE_POINT)
                 matchedEclCC = bestMatchEclCC_before;
 
-            static const TCHAR * const warningTpl = _T("Compiler/Server mismatch:\r\nCompiler:\t%1%\r\nServer:\t%2%");
             if (matchedEclCC)
             {
-                matchedEclCC->m_warnings = (boost::_tformat(warningTpl) % matchedEclCC->GetBuild()->GetString() % serverVersion->GetString()).str();
+                std::_tstring eclccBuildStr, serverVersionStr;
+                matchedEclCC->m_warnings = (boost::_tformat(warningTpl) % matchedEclCC->GetBuild()->GetString(eclccBuildStr) % serverVersion->GetString(serverVersionStr)).str();
                 return matchedEclCC;
             }
 
             //  No good match, just return latest  ---
             matchedEclCC = foundCompilers.rbegin()->get();
-            matchedEclCC->m_errors = (boost::_tformat(warningTpl) % matchedEclCC->GetBuild()->GetString() % serverVersion->GetString()).str();
+            std::_tstring eclccBuildStr, serverVersionStr;
+            const std::_tstring errors = (boost::_tformat(warningTpl) % matchedEclCC->GetBuild()->GetString(eclccBuildStr) % serverVersion->GetString(serverVersionStr)).str();
+            matchedEclCC->m_errors = errors;
             matchedEclCC->m_errors += _T("\r\n(To prevent this message from showing, either download and install the matching client tools package or override the default compiler settings in the preferences window)\r\n");
             return matchedEclCC;
         }

--- a/comms/SMCVersion.cpp
+++ b/comms/SMCVersion.cpp
@@ -32,7 +32,7 @@ public:
     CVersion(const CString & url, const CString &version) : m_url(url), m_rawversion(version)
     {
         m_id = m_url + _T("/") + m_rawversion.c_str();
-#ifdef _DEBUG
+#ifdef _DEBUGUNITTEST
         //  <string>-|_<int>.<int>[<char>][.<int>].|-|_<string>[_<int>[<char>]]
         static bool unitTest = false;
         if (!unitTest)
@@ -94,15 +94,18 @@ public:
         return static_cast<float>(_tstof(m_strversion.c_str()));
     }
 
-    const TCHAR * GetString()
+    const TCHAR * GetString(std::_tstring & version)
     {
         clib::recursive_mutex::scoped_lock proc(m_mutex);
-        return m_strversion.c_str();
+        version = m_strversion;
+        return version.c_str();
     }
 
-    const TCHAR * GetPrefix() const
+    const TCHAR * GetPrefix(std::_tstring & prefix) const
     {
-        return m_parsedVersion.preffix.c_str();
+        clib::recursive_mutex::scoped_lock proc(m_mutex);
+        prefix = m_parsedVersion.prefix;
+        return prefix.c_str();
     }
 
     unsigned int GetMajor() const
@@ -120,9 +123,11 @@ public:
         return m_parsedVersion.pointVersion;
     }
 
-    const TCHAR * GetSuffixString() const
+    const TCHAR * GetSuffixString(std::_tstring & suffix) const
     {
-        return m_parsedVersion.suffixStr.c_str();
+        clib::recursive_mutex::scoped_lock proc(m_mutex);
+        suffix = m_parsedVersion.suffixStr;
+        return suffix.c_str();
     }
 
     unsigned int GetSuffixInteger() const

--- a/comms/SMCVersion.h
+++ b/comms/SMCVersion.h
@@ -9,13 +9,13 @@ const TCHAR * const DEFAULT_VERSION = _T("build_0_0");
 __interface IVersion : public IUnknown
 {
     float Get();
-    const TCHAR * GetString();
+    const TCHAR * GetString(std::_tstring & version);
 
-    const TCHAR * GetPrefix() const;
+    const TCHAR * GetPrefix(std::_tstring & prefix) const;
     unsigned int GetMajor() const;
     unsigned int GetMinor() const;
     unsigned int GetPoint() const;
-    const TCHAR * GetSuffixString() const;
+    const TCHAR * GetSuffixString(std::_tstring & suffix) const;
     unsigned int GetSuffixInteger() const;
     int Compare(const IVersion * other) const;
 };
@@ -31,9 +31,10 @@ public:
     };
     unsigned int distance(IVersion * l, IVersion * r)
     {
+        std::_tstring l_suffix, r_suffix;
         unsigned int retVal = 0;
         retVal += std::abs((int)r->GetSuffixInteger() - (int)l->GetSuffixInteger());
-        retVal += std::abs(_tcscmp(r->GetSuffixString(), l->GetSuffixString()))				* 100;
+        retVal += std::abs(_tcscmp(r->GetSuffixString(r_suffix), l->GetSuffixString(l_suffix)))				* 100;
         retVal += std::abs((int)r->GetPoint() - (int)l->GetPoint())							* 1000;
         retVal += std::abs((int)r->GetMinor() - (int)l->GetMinor())							* 100000;
         retVal += std::abs((int)r->GetMajor() - (int)l->GetMajor())							* 100000000;
@@ -42,27 +43,31 @@ public:
 
     bool equals(IVersion * l, IVersion * r) const
     {
-        return l->GetMajor() == r->GetMajor() && 
+        std::_tstring l_suffix, r_suffix;
+        return l->GetMajor() == r->GetMajor() &&
             l->GetMinor() == r->GetMinor() &&
             l->GetPoint() == r->GetPoint() &&
-            _tcscmp(l->GetSuffixString(), r->GetSuffixString()) == 0 &&
+            _tcscmp(l->GetSuffixString(l_suffix), r->GetSuffixString(r_suffix)) == 0 &&
             l->GetSuffixInteger() == r->GetSuffixInteger();
     }
 
     bool operator ()(IVersion * l, IVersion * r) const
     {
+        std::_tstring l_suffix, r_suffix;
         if (l->GetMajor() == r->GetMajor())
         {
             if (l->GetMinor() == r->GetMinor())
             {
                 if (l->GetPoint() == r->GetPoint())
                 {
-                    if (_tcslen(l->GetSuffixString()) && !_tcslen(r->GetSuffixString())) // "" > "rc" > "closedown"
+                    l->GetSuffixString(l_suffix);
+                    r->GetSuffixString(r_suffix);
+                    if (l_suffix.length() && !r_suffix.length()) // "" > "rc" > "closedown"
                         return true;
-                    else if (!_tcslen(l->GetSuffixString()) && _tcslen(r->GetSuffixString()))
+                    else if (!l_suffix.length() && r_suffix.length())
                         return false;
 
-                    int strComp = _tcscmp(l->GetSuffixString(), r->GetSuffixString());  // "rc" > "closedown"
+                    int strComp = _tcscmp(l_suffix.c_str(), r_suffix.c_str());  // "rc" > "closedown"
                     if (strComp == 0)
                         return l->GetSuffixInteger() < l->GetSuffixInteger();
 

--- a/wlib/AboutDlg.cpp
+++ b/wlib/AboutDlg.cpp
@@ -81,7 +81,8 @@ public:
 
 		m_server = _T("Server:\t\t");
 		CComPtr<SMC::IVersion> serverVersion = smc->GetBuild();
-		m_server += serverVersion->GetString();
+		std::_tstring version;
+		m_server += serverVersion->GetString(version);
 		SetDlgItemText(IDC_STATIC_SERVER, m_server.c_str());
 
 		m_compiler = _T("Compiler:\t");

--- a/wlib/SourceView.cpp
+++ b/wlib/SourceView.cpp
@@ -268,7 +268,6 @@ int CSourceCtrl::HandleNotify(Scintilla::SCNotification *notification)
     if (!notification)
         return 0;
 
-    ATLTRACE(_T("%i\n"), notification->nmhdr.code);
     switch (notification->nmhdr.code)
     {
     case SCEN_SETFOCUS:


### PR DESCRIPTION
Possible heap corruption string is changed en route into boost::format.
Disabled excess logging in debug mode.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>