### PR TITLE
IDE-786 Missing options on builder window

### DIFF
--- a/comms/Topology.cpp
+++ b/comms/Topology.cpp
@@ -61,17 +61,6 @@ unsigned GetClusters(const CString & url, const std::_tstring & queueFilter, ICl
     CachePoolAccessor<IClusterVector> knownClusters(*g_knownClusters.get(queueFilter), (const TCHAR *)url, queueFilter);
     if (knownClusters.needs_update())
     {
-        if (queueFilter.empty() || boost::algorithm::iequals(queueFilter, _T("Local")))
-        {
-            if (CComPtr<IEclCC> eclcc = CreateIEclCC())
-            {
-                StlLinked<ICluster> cluster = CreateCluster(url, _T("Local"), _T("Local"));
-                clusters->push_back(cluster);
-            }
-            //if (!queueFilter.empty())	//  Hack
-            //	return clusters->size();
-        }
-
         CSoapInitialize<WsTopologyServiceSoapProxy> server(url);
 
         _ns5__TpLogicalClusterQueryRequest request;

--- a/eclide/EclDlgBuilder.cpp
+++ b/eclide/EclDlgBuilder.cpp
@@ -275,13 +275,6 @@ LRESULT CBuilderDlg::OnInitDialog(HWND /*hWnd*/, LPARAM /*lParam*/)
         }
     }
 
-    if (IsLocalRepositoryEnabled())
-    {
-        ShowHide(IDC_STATIC_QUEUECLUSTER, true);
-        ShowHide(IDC_COMBO_QUEUECLUSTER, true);
-        ShowHide(IDC_BUTTON_ADVANCED, true);
-    }
-
     DoDataExchange();
 
     return 0;


### PR DESCRIPTION
Rollback IDE-786
Remove "Local" from target options

Fixes IDE-786

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>