### PR TITLE
IDE-786 Missing options on builder window

### DIFF
--- a/eclide/EclDlgBuilder.cpp
+++ b/eclide/EclDlgBuilder.cpp
@@ -274,13 +274,6 @@ LRESULT CBuilderDlg::OnInitDialog(HWND /*hWnd*/, LPARAM /*lParam*/)
         }
     }
 
-	if (IsLocalRepositoryEnabled())
-	{
-		ShowHide(IDC_STATIC_QUEUECLUSTER, true);
-		ShowHide(IDC_COMBO_QUEUECLUSTER, true);
-		ShowHide(IDC_BUTTON_ADVANCED, true);
-	}
-
     DoDataExchange();
 
     return 0;


### PR DESCRIPTION
Rollback IDE-755
Remove "Local" from target options

Fixes IDE-786

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>

# Conflicts:
#	eclide/EclDlgBuilder.cpp