### PR TITLE
IDE-731 Normalize directory path from metadata

### DIFF
--- a/comms/EclMeta.cpp
+++ b/comms/EclMeta.cpp
@@ -82,13 +82,13 @@ public:
 
 CEclFile *CEclMeta::GetSourceFromPath(const std::wstring & path)
 {
+    boost::filesystem::path pathIn = path;
     for (std::map<std::wstring, StlLinked<CEclMetaData>>::iterator itr = m_masterMeta.begin(); itr != m_masterMeta.end(); ++itr)
     {
         CEclMetaData *meta = itr->second;
         if (meta != NULL && meta->HasPath())
         {
-            std::_tstring pather = meta->GetPath().c_str();
-            if (boost::algorithm::equals(pather, path))
+            if (boost::filesystem::equivalent(meta->GetPath(),pathIn))
             {
                 return (CEclFile *)meta;
             }

--- a/wlib/EclCommand.h
+++ b/wlib/EclCommand.h
@@ -163,7 +163,7 @@ public:
         //we really shouldn't be setting these since we don't handle them
         UPDATEUI(cui, ID_FILE_SAVE, m_ecl->GetModify());	
         UPDATEUI(cui, ID_FILE_PRINT, TRUE);
-        UPDATEUI(cui, ID_ECL_CHECKSYNTAX, bCanSubmit);
+        UPDATEUI(cui, ID_ECL_CHECKSYNTAX, bHasContents);
         UPDATEUI(cui, ID_ECL_GOTOSYNCTOC, bHasContents);
 
         if (cui->m_nID == ID_MACRO_RECORD)


### PR DESCRIPTION
Normalize directory path from metadata. This used to be the third part of the sprint for F12 and better tooltip information. That has been pushed to IDE-807.