### PR TITLE
HPCC-21705 ECLIDE build fails with 7.0.22 branch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ endif()
 set ( CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_RPM_PACKAGE_VERSION}_${version}-${stagever}${CPACK_SYSTEM_NAME}" )
 MESSAGE ("-- Current release version is ${CPACK_PACKAGE_FILE_NAME}")
 
-find_file(CLIENTTOOLS_PACKAGE_FILE "hpccsystems-clienttools-${CPACK_RPM_PACKAGE_VERSION}_${version}-${stagever}${CPACK_SYSTEM_NAME}.exe" HINTS ${CMAKE_CURRENT_BINARY_DIR}/../HPCC-Platform )
+find_file(CLIENTTOOLS_PACKAGE_FILE "hpccsystems-clienttools-community_${version}-${stagever}${CPACK_SYSTEM_NAME}.exe" HINTS ${CMAKE_CURRENT_BINARY_DIR}/../HPCC-Platform )
 install ( PROGRAMS ${CLIENTTOOLS_PACKAGE_FILE} DESTINATION tmp )
 get_filename_component(CLIENTTOOLS_PACKAGE_FILE_NAME ${CLIENTTOOLS_PACKAGE_FILE} NAME)
 list ( APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS " 


### PR DESCRIPTION
Signed-off-by: Godson Fortil <FortGo01@LexisNexisRisk.Com>