### PR TITLE
IDE_931 IDE Crashes when workspace ecllib file is open

### DIFF
--- a/wlib/LangRef.cpp
+++ b/wlib/LangRef.cpp
@@ -529,7 +529,7 @@ public:
 		else
 		{
 			front = filefront;
-			type = boost::algorithm::equals(m_elementType, ATTRIBUTE_TYPE_PLUGIN) ? ATTRIBUTE_TYPE_ECL : m_elementType.c_str();
+			type = boost::algorithm::equals(m_elementType, ATTRIBUTE_TYPE_PLUGIN) || boost::algorithm::equals(m_elementType, ATTRIBUTE_TYPE_ECLLIB) ? ATTRIBUTE_TYPE_ECL : m_elementType.c_str();
 		}
 		type.MakeUpper();
 		CString formatStr = twoFlag ? _T("%s%s2.%s") : _T("%s%s.%s");


### PR DESCRIPTION
This should have been caught in a more thorough test of IDE-930.