### PR TITLE
IDE-953 _DBGLOG message for LEVEL_INFO displaying "WARNING" not "INFO"

### DIFF
--- a/clib/logger.cpp
+++ b/clib/logger.cpp
@@ -10,6 +10,7 @@ const TCHAR * const LEVEL_TEXT[] =
     _T("FINER:    "),
     _T("FINE:     "),
     _T("CONFIG:   "),
+    _T("DEBUG:     "),
     _T("INFO:     "),
     _T("WARNING:  "),
     _T("SEVERE:   ")


### PR DESCRIPTION
@GordonSmith for review

It didn't match: logger.h

```
enum LEVEL
{
    LEVEL_FINEST = 0,
    LEVEL_FINER, 
    LEVEL_FINE, 
    LEVEL_CONFIG,
    LEVEL_DEBUG,
    LEVEL_INFO,
    LEVEL_WARNING, 
    LEVEL_SEVERE
};
```