### PR TITLE
IDE-1013 change timestamp URL to http://timestamp.digicert.com

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,8 +229,8 @@ SET(CPACK_NSIS_DEFINES "
 IF (EXISTS "${PROJECT_SOURCE_DIR}/../sign/passphrase.txt")
     FILE(STRINGS "${PROJECT_SOURCE_DIR}/../sign/passphrase.txt" PFX_PASSWORD LIMIT_COUNT 1)
 
-    ADD_CUSTOM_TARGET(SIGN 
-        COMMAND signtool sign /f "${PROJECT_SOURCE_DIR}/../sign/hpcc_code_signing.pfx" /p "${PFX_PASSWORD}" /t "http://timestamp.globalsign.com/scripts/timstamp.dll" "${CMAKE_BINARY_DIR}/${CPACK_PACKAGE_NAME}*.exe"
+    ADD_CUSTOM_TARGET(SIGN
+        COMMAND signtool sign /f "${PROJECT_SOURCE_DIR}/../sign/hpcc_code_signing.pfx" /p "${PFX_PASSWORD}" /tr "http://timestamp.digicert.com" "${CMAKE_BINARY_DIR}/${CPACK_PACKAGE_NAME}*.exe"
         COMMENT "Digital Signature"
     )
     ADD_DEPENDENCIES(SIGN PACKAGE)


### PR DESCRIPTION
We experience a lots of signtool error "The specified timestamp server either could not be reached".
Thanks to Todd Leonard it seems http://timestamp.digicert.com with "/tr" is more stable.
The reference: https://knowledge.digicert.com/solution/SO912.html

We manually tested the setting and it run very well.

This fix should be applied to 7.12.x, 7.10.x and 7.8.x and master

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexis.com>

@GordonSmith  please review