### PR TITLE
Support ECLIDE build with  64bit Clienttools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ PROJECT(ECLIDE)
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# General Options ---
+option(EMBED_64BIT_CLIENTTOOLS "Embed 64bit client tools (OFF=32bit)" ON)
+
 # Build tag generation ---
 INCLUDE("${PROJECT_SOURCE_DIR}/version.cmake")
 
@@ -183,13 +186,17 @@ ENDIF()
 SET(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_RPM_PACKAGE_VERSION}_${version}-${stagever}${CPACK_SYSTEM_NAME}")
 MESSAGE ("-- Current release version is ${CPACK_PACKAGE_FILE_NAME}")
 
-find_file(CLIENTTOOLS_PACKAGE_FILE "hpccsystems-clienttools-community_${version}-${stagever}${CMAKE_SYSTEM_NAME}-${CPACK_RPM_PACKAGE_ARCHITECTURE}.exe" HINTS ${CMAKE_CURRENT_BINARY_DIR}/../HPCC-Platform )
+SET(CT_ARCH "i386")
+IF (EMBED_64BIT_CLIENTTOOLS)
+  SET(CT_ARCH "x86_64")
+ENDIF ()
+find_file(CLIENTTOOLS_PACKAGE_FILE "hpccsystems-clienttools-community_${version}-${stagever}${CMAKE_SYSTEM_NAME}-${CT_ARCH}.exe" HINTS ${CMAKE_CURRENT_BINARY_DIR}/../HPCC-Platform )
 MESSAGE ("-- Clienttools package: ${CLIENTTOOLS_PACKAGE_FILE}")
 if (CLIENTTOOLS_PACKAGE_FILE)
     install ( PROGRAMS ${CLIENTTOOLS_PACKAGE_FILE} DESTINATION tmp )
     get_filename_component(CLIENTTOOLS_PACKAGE_FILE_NAME ${CLIENTTOOLS_PACKAGE_FILE} NAME)
     list ( APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
-        ExecWait '$INSTDIR\\\\tmp\\\\${CLIENTTOOLS_PACKAGE_FILE_NAME} /S /D=$INSTDIR\\\\..\\\\clienttools'
+        ExecWait '$INSTDIR\\\\tmp\\\\${CLIENTTOOLS_PACKAGE_FILE_NAME} /S'
 ")
 endif (CLIENTTOOLS_PACKAGE_FILE)
 


### PR DESCRIPTION
Add a CMake flag CT_ARCH.
If this flag set to "i386" 32bit Clienttools will be used to build ECLIDE. The default is  64bit Clienttools.
Also remove hard-coded Clienttools installation location which will prevent 64bit Clienttools conversion and reboot prompt in ECLIDE installation.